### PR TITLE
fix: use public OIDC token for GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,6 @@ jobs:
     name: Sign Example Agent Card
     runs-on: ubuntu-latest
     needs: [build]
-    if: github.ref == 'refs/heads/main'
     permissions:
       contents: read
       id-token: write
@@ -150,22 +149,24 @@ jobs:
         run: |
           make install
 
+      - name: Store beacon token into oidc-token.txt
+        uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@5c7bac23e5652132c019d1273c94384412b9ef76 # main
+
       - name: Sign example Agent Card
         run: |
           uv run sigstore-a2a sign \
             --output signed-example.json \
             --repository ${{ github.repository }} \
             --provenance \
-            --use_ambient_credentials \
+            --identity_token "$(cat oidc-token.txt)" \
             example_agentcard.json
 
       - name: Verify signed Agent Card
         run: |
           uv run sigstore-a2a --verbose verify \
-            --identity "https://github.com/${{ github.workflow_ref }}" \
             --identity_provider "https://token.actions.githubusercontent.com" \
-            --repository ${{ github.repository }} \
-            --workflow "${{ github.workflow }}" \
+            --repository "sigstore-conformance/extremely-dangerous-public-oidc-beacon" \
+            --workflow "Extremely dangerous OIDC beacon" \
             signed-example.json
 
       - name: Upload signed Agent Card

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,21 +52,26 @@ jobs:
         run: |
           uv build
 
+      - name: Store beacon token into oidc-token.txt
+        uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@5c7bac23e5652132c019d1273c94384412b9ef76 # main
+
       - name: Sign release Agent Card
         env:
           UV_PRERELEASE: allow
         run: |
           uv run sigstore-a2a sign example_agentcard.json \
             --output release-signed-agent-card.json \
-            --repository ${{ github.repository }}
+            --repository ${{ github.repository }} \
+            --identity_token "$(cat oidc-token.txt)"
 
       - name: Verify release Agent Card
         env:
           UV_PRERELEASE: allow
         run: |
           uv run sigstore-a2a verify release-signed-agent-card.json \
-            --repository ${{ github.repository }} \
-            --workflow "${{ github.workflow }}"
+            --identity_provider "https://token.actions.githubusercontent.com" \
+            --repository "sigstore-conformance/extremely-dangerous-public-oidc-beacon" \
+            --workflow "Extremely dangerous OIDC beacon"
 
       - name: Generate changelog
         id: changelog


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary

Using public beacon token, enabling forks to run the full CI/CD without worry of accidental breakage once merged into main

Closes #10 
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed
