### PR TITLE
(fix): preserve original agent card key order in signed output

### DIFF
--- a/sigstore_a2a/cli/sign.py
+++ b/sigstore_a2a/cli/sign.py
@@ -230,7 +230,7 @@ def sign_cmd(
             out_path.parent.mkdir(parents=True, exist_ok=True)
             with open(out_path, "w", encoding="utf-8", newline="\n") as f:
                 json.dump(
-                    signed_card.model_dump(by_alias=True, exclude_none=True),
+                    signed_card.to_dict(),
                     f,
                     indent=2,
                     ensure_ascii=False,

--- a/sigstore_a2a/signer.py
+++ b/sigstore_a2a/signer.py
@@ -163,6 +163,7 @@ class AgentCardSigner:
         attestations = Attestations(signature_bundle=bundle.to_json(), provenance_bundle=provenance_bundle)
 
         signed_card = SignedAgentCard(agent_card=parsed_card, attestations=attestations)
+        signed_card._raw_card_data = card_data
 
         return signed_card
 
@@ -192,6 +193,6 @@ class AgentCardSigner:
         signed_card = self.sign_agent_card(input_path, provenance_bundle)
 
         with open(output_path, "w") as f:
-            json.dump(signed_card.model_dump(by_alias=True), f, indent=2, default=str)
+            json.dump(signed_card.to_dict(), f, indent=2, default=str)
 
         return output_path


### PR DESCRIPTION
<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->
Pydantic's model_dump() re-serialized AgentCard fields alphabetically, losing the original JSON key order. 
By storing the raw card data dict and useing it during serialization via a new `to_dict()` method on SignedAgentCard it is possible to preserve the original key order of the agent card in the signed output.

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed
