### PR TITLE
feat: migrate from a2a-sdk 0.2.x Pydantic types to 1.x protobuf types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,8 +90,10 @@ jobs:
       - name: Install dependencies
         run: make install
 
-      - name: Get OIDC token
-        uses: sigstore-conformance/extremely-dangerous-public-oidc-beacon@main
+      - name: Fetch OIDC token
+        run: |
+          SIGSTORE_ID_TOKEN=$(curl -sSfL https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt)
+          echo "SIGSTORE_ID_TOKEN=$SIGSTORE_ID_TOKEN" >> "$GITHUB_ENV"
 
       - name: Sign GeoRoute Agent Card
         run: |
@@ -99,7 +101,7 @@ jobs:
             --output signed-georoute-agent.json \
             --repository ${{ github.repository }} \
             --provenance \
-            --identity_token "$(cat oidc-token.txt)" \
+            --identity_token "${SIGSTORE_ID_TOKEN}" \
             examples/georoute-agent.json
 
       - name: Sign Data Analysis Agent Card
@@ -108,23 +110,21 @@ jobs:
             --output signed-data-analysis-agent.json \
             --repository ${{ github.repository }} \
             --provenance \
-            --identity_token "$(cat oidc-token.txt)" \
+            --identity_token "${SIGSTORE_ID_TOKEN}" \
             examples/data-analysis-agent.json
 
       - name: Verify GeoRoute Agent Card
         run: |
           uv run sigstore-a2a --verbose verify \
-            --identity_provider "https://token.actions.githubusercontent.com" \
-            --repository "sigstore-conformance/extremely-dangerous-public-oidc-beacon" \
-            --workflow "Extremely dangerous OIDC beacon" \
+            --identity "untrusted-sa@sigstore-conformance.iam.gserviceaccount.com" \
+            --identity_provider "https://accounts.google.com" \
             signed-georoute-agent.json
 
       - name: Verify Data Analysis Agent Card
         run: |
           uv run sigstore-a2a --verbose verify \
-            --identity_provider "https://token.actions.githubusercontent.com" \
-            --repository "sigstore-conformance/extremely-dangerous-public-oidc-beacon" \
-            --workflow "Extremely dangerous OIDC beacon" \
+            --identity "untrusted-sa@sigstore-conformance.iam.gserviceaccount.com" \
+            --identity_provider "https://accounts.google.com" \
             signed-data-analysis-agent.json
 
       - name: Upload signed Agent Cards

--- a/README.md
+++ b/README.md
@@ -300,6 +300,14 @@ class AgentCardVerifier:
 - `staging`: Use Sigstore staging environment
 - `constraints`: IdentityConstraints object for repository/workflow verification
 
+**VerificationResult fields:**
+- `valid`: Whether verification succeeded
+- `agent_card`: Verified AgentCard (protobuf message, extracted from DSSE payload)
+- `raw_card_data`: Raw predicate dict from the DSSE payload, preserving fields that may not map to the current protobuf schema (e.g., `url` from v0.2.x cards)
+- `certificate`: Signing certificate
+- `identity`: Extracted identity information
+- `errors`: List of verification errors
+
 ### ProvenanceBuilder
 
 ```python

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -54,7 +54,7 @@ signed_card = SignedAgentCard.model_validate(data)
 
 # Access the agent card
 print(f"Agent: {signed_card.agent_card.name}")
-print(f"URL: {signed_card.agent_card.url}")
+print(f"URL: {signed_card.url}")  # uses supported_interfaces (v1.0) or empty string
 
 # Access attestations
 print(f"Has signature: {signed_card.attestations.signature_bundle is not None}")
@@ -89,7 +89,7 @@ signed_card = signer.sign_agent_card("agent-card.json")
 
 # Serialize to JSON
 json_str = json.dumps(
-    signed_card.model_dump(by_alias=True),
+    signed_card.to_dict(),
     indent=2,
     default=str
 )

--- a/docs/api/signer.md
+++ b/docs/api/signer.md
@@ -108,7 +108,7 @@ signed_card = signer.sign_agent_card("agent-card.json")
 
 # Save to file
 with open("signed-card.json", "w") as f:
-    json.dump(signed_card.model_dump(by_alias=True), f, indent=2)
+    json.dump(signed_card.to_dict(), f, indent=2)
 
 # Or use sign_file for convenience
 output_path = signer.sign_file(

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,7 +88,7 @@ signed_card = signer.sign_agent_card(card_data)
 # Save the signed card
 import json
 with open("signed-card.json", "w") as f:
-    json.dump(signed_card.model_dump(by_alias=True), f, indent=2)
+    json.dump(signed_card.to_dict(), f, indent=2)
 ```
 
 ### CI/CD Integration

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@ This directory contains example A2A Agent Card JSON files for testing and demons
 
 ## Signed Agent Cards (Staging)
 
-Pre-signed examples using Sigstore **staging** environment with the [OIDC beacon](https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon) identity.
+Pre-signed examples using Sigstore **staging** environment with the [sigstore-conformance testing token](https://storage.googleapis.com/sigstore-conformance-testing-token/untrusted-testing-token.txt) identity.
 
 - `signed-georoute-agent.json`
 - `signed-data-analysis-agent.json`
@@ -19,8 +19,8 @@ Pre-signed examples using Sigstore **staging** environment with the [OIDC beacon
 ```bash
 sigstore-a2a verify examples/signed-georoute-agent.json \
   --staging \
-  --identity_provider https://token.actions.githubusercontent.com \
-  --identity "https://github.com/sigstore-conformance/extremely-dangerous-public-oidc-beacon/.github/workflows/extremely-dangerous-oidc-beacon.yml@refs/heads/main"
+  --identity_provider https://accounts.google.com \
+  --identity "untrusted-sa@sigstore-conformance.iam.gserviceaccount.com"
 ```
 
 ## Usage

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,8 @@ classifiers = [
   "Typing :: Typed",
 ]
 dependencies = [
-    "a2a-sdk>=0.2.16",
+    "a2a-sdk>=1.0.0,<2.0.0",
+    "protobuf>=4.0.0",
     "sigstore>=4.2.0",
     "pydantic>=2.0.0,<3.0.0",
     "click>=8.0.0",

--- a/sigstore_a2a/cli/main.py
+++ b/sigstore_a2a/cli/main.py
@@ -48,9 +48,8 @@ def _validate_trust_options(staging: bool, instance: str | None, trust_config: P
     """Validate that trust options are mutually exclusive."""
     opts = sum(bool(x) for x in [staging, instance, trust_config])
     if opts > 1:
-        raise click.ClickException(
-            "Options --staging, --instance, and --trust_config are mutually exclusive"
-        )
+        raise click.ClickException("Options --staging, --instance, and --trust_config are mutually exclusive")
+
 
 # Signing inputs / outputs
 _agent_card_arg = click.argument("agent_card", type=click.Path(exists=True, path_type=Path))

--- a/sigstore_a2a/cli/serve.py
+++ b/sigstore_a2a/cli/serve.py
@@ -20,6 +20,7 @@ import click
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import JSONResponse
+from google.protobuf.json_format import MessageToDict
 from rich.console import Console
 
 from ..models.signature import SignedAgentCard
@@ -49,7 +50,7 @@ def create_app(signed_card_path: Path, verify_on_serve: bool = True, staging: bo
                 app_state["signed_card_data"] = json.load(f)
 
             signed_card = SignedAgentCard.model_validate(app_state["signed_card_data"])
-            app_state["agent_card_data"] = signed_card.agent_card.model_dump(by_alias=True, mode="json")
+            app_state["agent_card_data"] = MessageToDict(signed_card.agent_card)
 
             if verify_on_serve:
                 verifier = AgentCardVerifier(

--- a/sigstore_a2a/cli/serve.py
+++ b/sigstore_a2a/cli/serve.py
@@ -111,7 +111,10 @@ def create_app(signed_card_path: Path, verify_on_serve: bool = True, staging: bo
                 "agent": {
                     "name": app_state["agent_card_data"].get("name"),
                     "version": app_state["agent_card_data"].get("version"),
-                    "url": app_state["agent_card_data"].get("url"),
+                    "url": next(
+                        (i["url"] for i in app_state["agent_card_data"].get("supportedInterfaces", [])),
+                        app_state["agent_card_data"].get("url"),
+                    ),
                 },
                 "endpoints": {
                     "agent_card": "/.well-known/agent.json",

--- a/sigstore_a2a/cli/verify.py
+++ b/sigstore_a2a/cli/verify.py
@@ -191,7 +191,7 @@ def verify_cmd(
                 if url:
                     table.add_row("URL", url)
 
-                if result.agent_card.provider:
+                if result.agent_card.HasField("provider"):
                     table.add_row("Provider", result.agent_card.provider.organization)
 
                 console.print(table)

--- a/sigstore_a2a/cli/verify.py
+++ b/sigstore_a2a/cli/verify.py
@@ -182,8 +182,14 @@ def verify_cmd(
 
                 table.add_row("Name", result.agent_card.name)
                 table.add_row("Version", result.agent_card.version)
-                table.add_row("URL", str(result.agent_card.url))
-                table.add_row("Protocol Version", result.agent_card.protocol_version)
+
+                url = ""
+                if result.agent_card.supported_interfaces:
+                    url = str(result.agent_card.supported_interfaces[0].url)
+                elif result.raw_card_data.get("url"):
+                    url = str(result.raw_card_data["url"])
+                if url:
+                    table.add_row("URL", url)
 
                 if result.agent_card.provider:
                     table.add_row("Provider", result.agent_card.provider.organization)

--- a/sigstore_a2a/models/signature.py
+++ b/sigstore_a2a/models/signature.py
@@ -16,6 +16,7 @@ import json
 from typing import Any
 
 from a2a.types import AgentCard
+from google.protobuf.json_format import MessageToDict, ParseDict
 from pydantic import BaseModel, ConfigDict, Field, PrivateAttr, field_serializer, field_validator
 from sigstore.models import Bundle
 
@@ -62,19 +63,31 @@ class SignedAgentCard(BaseModel):
 
     _raw_card_data: dict[str, Any] | None = PrivateAttr(default=None)
 
-    model_config = {"populate_by_name": True}
+    model_config = ConfigDict(
+        arbitrary_types_allowed=True,
+        populate_by_name=True,
+    )
+
+    @field_validator("agent_card", mode="before")
+    @classmethod
+    def _agent_card_in(cls, v):
+        if isinstance(v, AgentCard):
+            return v
+        if isinstance(v, dict):
+            return ParseDict(v, AgentCard(), ignore_unknown_fields=True)
+        raise TypeError("Expected AgentCard protobuf message or dict")
+
+    @field_serializer("agent_card")
+    def _agent_card_out(self, v: AgentCard, _info):
+        return MessageToDict(v)
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize preserving the original agent card key order.
 
         Uses the raw card data (original JSON key order) when available,
-        falling back to Pydantic's model_dump otherwise.
+        falling back to protobuf MessageToDict otherwise.
         """
-        card_data = (
-            self._raw_card_data
-            if self._raw_card_data is not None
-            else self.agent_card.model_dump(by_alias=True)
-        )
+        card_data = self._raw_card_data if self._raw_card_data is not None else MessageToDict(self.agent_card)
         attestations = self.attestations.model_dump(by_alias=True, exclude_none=True)
         return {"agentCard": card_data, "attestations": attestations}
 
@@ -90,8 +103,11 @@ class SignedAgentCard(BaseModel):
 
     @property
     def url(self) -> str:
-        """Get the agent URL."""
-        return str(self.agent_card.url)
+        """Get the agent URL from the first supported interface."""
+        interfaces = self.agent_card.supported_interfaces
+        if interfaces:
+            return str(interfaces[0].url)
+        return ""
 
 
 def _to_jsonable(v: Any) -> Any:

--- a/sigstore_a2a/provenance.py
+++ b/sigstore_a2a/provenance.py
@@ -18,6 +18,7 @@ from pathlib import Path
 from typing import Any
 
 from a2a.types import AgentCard
+from google.protobuf.json_format import MessageToDict, ParseDict
 
 from .models.provenance import (
     BuilderIdentity,
@@ -65,7 +66,7 @@ class ProvenanceBuilder:
         elif isinstance(agent_card, dict):
             card_data = agent_card
         elif isinstance(agent_card, AgentCard):
-            card_data = agent_card.model_dump(by_alias=True)
+            card_data = MessageToDict(agent_card)
         else:
             raise ValueError(f"Invalid agent card type: {type(agent_card)}")
 
@@ -80,7 +81,7 @@ class ProvenanceBuilder:
 
         # Use agent name if not provided
         if name is None:
-            parsed_card = AgentCard.model_validate(card_data)
+            parsed_card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
             name = f"{parsed_card.name}-{parsed_card.version}"
 
         return ProvenanceSubject(name=name, digest=digest_set)

--- a/sigstore_a2a/signer.py
+++ b/sigstore_a2a/signer.py
@@ -17,6 +17,7 @@ from pathlib import Path
 from typing import Any
 
 from a2a.types import AgentCard
+from google.protobuf.json_format import MessageToDict, ParseDict
 from sigstore.dsse import DigestSet, StatementBuilder, Subject
 from sigstore.models import ClientTrustConfig
 from sigstore.oidc import IdentityToken, Issuer, detect_credential
@@ -122,11 +123,11 @@ class AgentCardSigner:
         elif isinstance(agent_card, dict):
             card_data = agent_card
         elif isinstance(agent_card, AgentCard):
-            card_data = agent_card.model_dump(by_alias=True)
+            card_data = MessageToDict(agent_card)
         else:
             raise ValueError(f"Invalid agent card type: {type(agent_card)}")
         try:
-            parsed_card = AgentCard.model_validate(card_data)
+            parsed_card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
         except Exception as e:
             raise ValueError(f"Invalid agent card: {e}") from e
 

--- a/sigstore_a2a/verifier.py
+++ b/sigstore_a2a/verifier.py
@@ -67,6 +67,7 @@ class VerificationResult:
         certificate: x509.Certificate | None = None,
         identity: dict[str, Any] | None = None,
         errors: list[str] | None = None,
+        raw_card_data: dict[str, Any] | None = None,
     ):
         """Initialize verification result.
 
@@ -76,12 +77,15 @@ class VerificationResult:
             certificate: Signing certificate
             identity: Extracted identity information
             errors: List of verification errors
+            raw_card_data: Raw predicate dict from the DSSE payload, preserving
+                fields that may not map to the current protobuf schema
         """
         self.valid = valid
         self.agent_card = agent_card
         self.certificate = certificate
         self.identity = identity or {}
         self.errors = errors or []
+        self.raw_card_data = raw_card_data or {}
 
     def __bool__(self) -> bool:
         """Return True if verification was successful."""
@@ -243,19 +247,23 @@ class AgentCardVerifier:
 
         return SignedAgentCard.model_validate(card_data)
 
-    def _extract_verified_card(self, payload: bytes) -> AgentCard:
+    def _extract_verified_card(self, payload: bytes) -> tuple[AgentCard, dict[str, Any]]:
         """Extract the agent card from the verified DSSE payload.
 
         After sigstore verifies the DSSE signature, the statement payload is
         the authenticated data.  We parse the agent card from the statement's
         predicate rather than trusting the outer SignedAgentCard wrapper, which
         could have been tampered with independently of the bundle.
+
+        Returns both the parsed protobuf AgentCard and the raw predicate dict,
+        since fields from older schema versions may not map to the current
+        protobuf definition but are still part of the authenticated payload.
         """
         statement = json.loads(payload)
         signed_predicate = statement.get("predicate")
         if signed_predicate is None or not isinstance(signed_predicate, dict):
             raise ValueError("DSSE statement does not contain a valid predicate")
-        return ParseDict(signed_predicate, AgentCard(), ignore_unknown_fields=True)
+        return ParseDict(signed_predicate, AgentCard(), ignore_unknown_fields=True), signed_predicate
 
     def verify_signed_card(
         self,
@@ -297,7 +305,7 @@ class AgentCardVerifier:
         #    This is the source of truth, not the outer wrapper, which could
         #    have been modified independently of the Sigstore bundle.
         try:
-            verified_card = self._extract_verified_card(payload)
+            verified_card, raw_card_data = self._extract_verified_card(payload)
         except Exception as e:
             return VerificationResult(valid=False, errors=[f"Failed to parse agent card from DSSE payload: {e}"])
 
@@ -305,7 +313,11 @@ class AgentCardVerifier:
         identity = self._extract_identity(sig_bundle.signing_certificate)
 
         return VerificationResult(
-            valid=True, agent_card=verified_card, certificate=sig_bundle.signing_certificate, identity=identity
+            valid=True,
+            agent_card=verified_card,
+            certificate=sig_bundle.signing_certificate,
+            identity=identity,
+            raw_card_data=raw_card_data,
         )
 
     def verify_file(self, file_path: str | Path, constraints: IdentityConstraints | None = None) -> VerificationResult:

--- a/sigstore_a2a/verifier.py
+++ b/sigstore_a2a/verifier.py
@@ -18,6 +18,7 @@ from typing import Any
 
 from a2a.types import AgentCard
 from cryptography import x509
+from google.protobuf.json_format import ParseDict
 from sigstore.models import ClientTrustConfig
 from sigstore.verify import Verifier
 from sigstore.verify.policy import (
@@ -254,7 +255,7 @@ class AgentCardVerifier:
         signed_predicate = statement.get("predicate")
         if signed_predicate is None or not isinstance(signed_predicate, dict):
             raise ValueError("DSSE statement does not contain a valid predicate")
-        return AgentCard.model_validate(signed_predicate)
+        return ParseDict(signed_predicate, AgentCard(), ignore_unknown_fields=True)
 
     def verify_signed_card(
         self,

--- a/tests/historic/v0_2_x/agentcard.json
+++ b/tests/historic/v0_2_x/agentcard.json
@@ -1,0 +1,46 @@
+{
+  "protocolVersion": "0.2.9",
+  "name": "GeoSpatial Route Planner Agent",
+  "description": "Provides advanced route planning, traffic analysis, and custom map generation services.",
+  "url": "https://georoute-agent.example.com/a2a/v1",
+  "preferredTransport": "JSONRPC",
+  "additionalInterfaces": [
+    {"url": "https://georoute-agent.example.com/a2a/v1", "transport": "JSONRPC"},
+    {"url": "https://georoute-agent.example.com/a2a/grpc", "transport": "GRPC"}
+  ],
+  "provider": {
+    "organization": "Example Geo Services Inc.",
+    "url": "https://www.examplegeoservices.com"
+  },
+  "iconUrl": "https://georoute-agent.example.com/icon.png",
+  "version": "1.2.0",
+  "documentationUrl": "https://docs.examplegeoservices.com/georoute-agent/api",
+  "capabilities": {
+    "streaming": true,
+    "pushNotifications": true,
+    "stateTransitionHistory": false
+  },
+  "securitySchemes": {
+    "google": {
+      "type": "openIdConnect",
+      "openIdConnectUrl": "https://accounts.google.com/.well-known/openid-configuration"
+    }
+  },
+  "security": [{"google": ["openid", "profile", "email"]}],
+  "defaultInputModes": ["application/json", "text/plain"],
+  "defaultOutputModes": ["application/json", "image/png"],
+  "skills": [
+    {
+      "id": "route-optimizer-traffic",
+      "name": "Traffic-Aware Route Optimizer",
+      "description": "Calculates optimal driving routes with real-time traffic.",
+      "tags": ["maps", "routing", "navigation", "traffic"],
+      "examples": [
+        "Plan a route from Mountain View to SFO avoiding tolls."
+      ],
+      "inputModes": ["application/json", "text/plain"],
+      "outputModes": ["application/json"]
+    }
+  ],
+  "supportsAuthenticatedExtendedCard": true
+}

--- a/tests/historic/v0_2_x/agentcard_minimal.json
+++ b/tests/historic/v0_2_x/agentcard_minimal.json
@@ -1,0 +1,11 @@
+{
+  "protocolVersion": "0.2.9",
+  "name": "Minimal Legacy Agent",
+  "description": "A minimal v0.2.x agent card with only required fields.",
+  "url": "https://minimal-agent.example.com",
+  "version": "0.1.0",
+  "capabilities": {},
+  "defaultInputModes": ["application/json"],
+  "defaultOutputModes": ["application/json"],
+  "skills": []
+}

--- a/tests/historic/v1_0/agentcard.json
+++ b/tests/historic/v1_0/agentcard.json
@@ -1,0 +1,21 @@
+{
+  "name": "GeoSpatial Route Planner Agent",
+  "description": "Provides advanced route planning, traffic analysis, and custom map generation services.",
+  "supportedInterfaces": [
+    {"url": "https://georoute-agent.example.com/a2a/v1"},
+    {"url": "https://georoute-agent.example.com/a2a/grpc"}
+  ],
+  "provider": {
+    "organization": "Example Geo Services Inc.",
+    "url": "https://www.examplegeoservices.com"
+  },
+  "version": "2.0.0",
+  "skills": [
+    {
+      "id": "route-optimizer-traffic",
+      "name": "Traffic-Aware Route Optimizer",
+      "description": "Calculates optimal driving routes with real-time traffic.",
+      "tags": ["maps", "routing", "navigation", "traffic"]
+    }
+  ]
+}

--- a/tests/historic/v1_0/agentcard_minimal.json
+++ b/tests/historic/v1_0/agentcard_minimal.json
@@ -1,0 +1,6 @@
+{
+  "name": "Minimal V1 Agent",
+  "description": "A minimal v1.0 agent card.",
+  "version": "1.0.0",
+  "skills": []
+}

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -1,0 +1,413 @@
+# Copyright 2025 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Backward and forward compatibility tests for AgentCard schema versions.
+
+Maintains historic AgentCard fixtures from different a2a-sdk versions and
+verifies that the current code can parse, serialize, and verify cards from
+all supported schema versions. This is the sigstore-a2a equivalent of
+model-transparency's historic signature tests.
+
+Fixture layout:
+    tests/historic/v0_2_x/   -- cards signed with a2a-sdk 0.2.x (Pydantic)
+    tests/historic/v1_0/     -- cards using a2a-sdk 1.x (protobuf)
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from a2a.types import AgentCard
+from google.protobuf.json_format import MessageToDict, ParseDict
+
+from sigstore_a2a.models.signature import SignedAgentCard
+from sigstore_a2a.verifier import AgentCardVerifier
+
+FIXTURES_DIR = Path(__file__).parent / "historic"
+
+# ---------------------------------------------------------------------------
+# Historic fixture data — fields unique to each schema version
+# ---------------------------------------------------------------------------
+
+V0_2_X_ONLY_FIELDS = [
+    "protocolVersion",
+    "url",
+    "preferredTransport",
+    "additionalInterfaces",
+    "security",
+    "supportsAuthenticatedExtendedCard",
+]
+
+V1_0_ONLY_FIELDS = [
+    "supportedInterfaces",
+]
+
+# Fields that survived across both schema versions
+COMMON_FIELDS = ["name", "description", "version", "skills", "provider"]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _load_fixture(version_dir: str, filename: str) -> dict[str, Any]:
+    """Load a JSON fixture from the versioned historic test data directory."""
+    path = FIXTURES_DIR / version_dir / filename
+    return json.loads(path.read_text())
+
+
+def _make_dsse_payload(predicate: dict) -> bytes:
+    """Create an in-toto statement payload wrapping the given predicate."""
+    statement = {
+        "_type": "https://in-toto.io/Statement/v0.1",
+        "subject": [{"name": predicate.get("name", "test"), "digest": {"sha256": "deadbeef"}}],
+        "predicateType": "https://a2a.openwallet.dev/agentcard/v1",
+        "predicate": predicate,
+    }
+    return json.dumps(statement).encode()
+
+
+def _mock_certificate():
+    """Create a minimal mock X.509 certificate with no extensions."""
+    from cryptography import x509
+
+    cert = MagicMock()
+    cert.extensions = MagicMock()
+    cert.extensions.get_extension_for_oid = MagicMock(
+        side_effect=x509.ExtensionNotFound("not found", x509.oid.ExtensionOID.SUBJECT_ALTERNATIVE_NAME)
+    )
+    cert.extensions.__iter__ = MagicMock(return_value=iter([]))
+    return cert
+
+
+def _mock_bundle(card_data: dict):
+    """Create a mock Bundle whose payload matches the given card data."""
+    bundle = MagicMock()
+    bundle.signing_certificate = _mock_certificate()
+    bundle._payload = _make_dsse_payload(card_data)
+    return bundle
+
+
+def _setup_verifier_with_card(card_data: dict) -> AgentCardVerifier:
+    """Create a verifier with mocked sigstore backend returning the given card data."""
+    agent_card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+    card_json = MessageToDict(agent_card)
+
+    mock_signed_card = MagicMock()
+    mock_signed_card.agent_card = agent_card
+    mock_signed_card.attestations.signature_bundle = _mock_bundle(card_json)
+
+    mock_sig_verifier = MagicMock()
+    mock_sig_verifier.verify_dsse.return_value = (
+        "application/vnd.in-toto+json",
+        _make_dsse_payload(card_data),
+    )
+
+    verifier = AgentCardVerifier()
+    verifier._parse_signed_card = MagicMock(return_value=mock_signed_card)
+    verifier._get_verifier = MagicMock(return_value=mock_sig_verifier)
+    return verifier
+
+
+# ---------------------------------------------------------------------------
+# Test: ParseDict compatibility across schema versions
+# ---------------------------------------------------------------------------
+
+
+class TestParseDictCompat:
+    """Verify that ParseDict with ignore_unknown_fields=True can parse cards from all schema versions."""
+
+    @pytest.mark.parametrize(
+        "version_dir,filename",
+        [
+            ("v0_2_x", "agentcard.json"),
+            ("v0_2_x", "agentcard_minimal.json"),
+            ("v1_0", "agentcard.json"),
+            ("v1_0", "agentcard_minimal.json"),
+        ],
+    )
+    def test_parse_succeeds(self, version_dir: str, filename: str):
+        """ParseDict must not raise for any supported schema version."""
+        card_data = _load_fixture(version_dir, filename)
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+        assert card.name == card_data["name"]
+        assert card.version == card_data["version"]
+
+    @pytest.mark.parametrize(
+        "version_dir,filename",
+        [
+            ("v0_2_x", "agentcard.json"),
+            ("v0_2_x", "agentcard_minimal.json"),
+        ],
+    )
+    def test_v0_2_x_core_fields_survive(self, version_dir: str, filename: str):
+        """Core identity fields from v0.2.x cards must survive protobuf parsing."""
+        card_data = _load_fixture(version_dir, filename)
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+
+        assert card.name == card_data["name"]
+        assert card.description == card_data["description"]
+        assert card.version == card_data["version"]
+        assert len(card.skills) == len(card_data["skills"])
+        for i, skill in enumerate(card.skills):
+            assert skill.name == card_data["skills"][i]["name"]
+
+    def test_v1_0_supported_interfaces_parsed(self):
+        """v1.0 cards with supportedInterfaces must parse correctly."""
+        card_data = _load_fixture("v1_0", "agentcard.json")
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+
+        assert len(card.supported_interfaces) == 2
+        assert card.supported_interfaces[0].url == "https://georoute-agent.example.com/a2a/v1"
+
+    def test_v0_2_x_unknown_fields_dropped_silently(self):
+        """Fields unique to v0.2.x must be silently dropped, not cause errors."""
+        card_data = _load_fixture("v0_2_x", "agentcard.json")
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+        card_dict = MessageToDict(card)
+
+        for field in V0_2_X_ONLY_FIELDS:
+            assert field not in card_dict, f"v0.2.x-only field '{field}' should have been dropped"
+
+
+# ---------------------------------------------------------------------------
+# Test: SignedAgentCard model compatibility
+# ---------------------------------------------------------------------------
+
+
+def _build_signed_card(card_data: dict) -> SignedAgentCard:
+    """Build a SignedAgentCard with a mocked Attestations bundle."""
+    agent_card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+    attestations = MagicMock()
+    attestations.model_dump.return_value = {"signatureBundle": {}}
+    signed = SignedAgentCard.__new__(SignedAgentCard)
+    object.__setattr__(signed, "agent_card", agent_card)
+    object.__setattr__(signed, "attestations", attestations)
+    object.__setattr__(signed, "_raw_card_data", card_data)
+    return signed
+
+
+class TestSignedAgentCardCompat:
+    """Verify that SignedAgentCard can wrap cards from all schema versions."""
+
+    @pytest.mark.parametrize(
+        "version_dir,filename",
+        [
+            ("v0_2_x", "agentcard.json"),
+            ("v0_2_x", "agentcard_minimal.json"),
+            ("v1_0", "agentcard.json"),
+            ("v1_0", "agentcard_minimal.json"),
+        ],
+    )
+    def test_signed_card_preserves_identity_fields(self, version_dir: str, filename: str):
+        """SignedAgentCard must preserve core identity fields from any schema version."""
+        card_data = _load_fixture(version_dir, filename)
+        signed = _build_signed_card(card_data)
+
+        assert signed.name == card_data["name"]
+        assert signed.version == card_data["version"]
+
+    def test_v0_2_x_card_url_property_falls_back(self):
+        """The url property must return empty string for old cards without supported_interfaces."""
+        card_data = _load_fixture("v0_2_x", "agentcard.json")
+        signed = _build_signed_card(card_data)
+        assert signed.url == ""
+
+    def test_v1_0_card_url_property_uses_supported_interfaces(self):
+        """The url property must return the first supported interface URL for v1.0 cards."""
+        card_data = _load_fixture("v1_0", "agentcard.json")
+        signed = _build_signed_card(card_data)
+        assert signed.url == "https://georoute-agent.example.com/a2a/v1"
+
+    @pytest.mark.parametrize(
+        "version_dir,filename",
+        [
+            ("v0_2_x", "agentcard.json"),
+            ("v1_0", "agentcard.json"),
+        ],
+    )
+    def test_to_dict_roundtrip(self, version_dir: str, filename: str):
+        """to_dict must produce a serializable dict for cards from any schema version."""
+        card_data = _load_fixture(version_dir, filename)
+        signed = _build_signed_card(card_data)
+
+        result = signed.to_dict()
+        assert "agentCard" in result
+        assert "attestations" in result
+        assert result["agentCard"]["name"] == card_data["name"]
+        json.dumps(result)
+
+
+# ---------------------------------------------------------------------------
+# Test: Verification flow with historic card formats
+# ---------------------------------------------------------------------------
+
+
+class TestVerificationCompat:
+    """Verify the full verification flow preserves backward compatibility."""
+
+    @pytest.mark.parametrize(
+        "version_dir,filename",
+        [
+            ("v0_2_x", "agentcard.json"),
+            ("v0_2_x", "agentcard_minimal.json"),
+            ("v1_0", "agentcard.json"),
+            ("v1_0", "agentcard_minimal.json"),
+        ],
+    )
+    def test_verification_succeeds_for_all_versions(self, version_dir: str, filename: str):
+        """Verification must succeed for cards from any supported schema version."""
+        card_data = _load_fixture(version_dir, filename)
+        verifier = _setup_verifier_with_card(card_data)
+
+        result = verifier.verify_signed_card({"agentCard": card_data})
+        assert result.valid is True
+        assert result.agent_card is not None
+        assert result.agent_card.name == card_data["name"]
+
+    @pytest.mark.parametrize(
+        "version_dir,filename",
+        [
+            ("v0_2_x", "agentcard.json"),
+            ("v0_2_x", "agentcard_minimal.json"),
+        ],
+    )
+    def test_v0_2_x_raw_card_data_preserves_legacy_fields(self, version_dir: str, filename: str):
+        """raw_card_data must retain v0.2.x fields that ParseDict drops."""
+        card_data = _load_fixture(version_dir, filename)
+        verifier = _setup_verifier_with_card(card_data)
+
+        result = verifier.verify_signed_card({"agentCard": card_data})
+        assert result.valid is True
+
+        assert result.raw_card_data.get("url") == card_data.get("url")
+        assert result.raw_card_data.get("protocolVersion") == card_data.get("protocolVersion")
+
+    def test_v0_2_x_full_card_all_legacy_fields_in_raw_data(self):
+        """Every v0.2.x-only field must be preserved in raw_card_data."""
+        card_data = _load_fixture("v0_2_x", "agentcard.json")
+        verifier = _setup_verifier_with_card(card_data)
+
+        result = verifier.verify_signed_card({"agentCard": card_data})
+        assert result.valid is True
+
+        for field in V0_2_X_ONLY_FIELDS:
+            if field in card_data:
+                assert field in result.raw_card_data, f"Legacy field '{field}' missing from raw_card_data"
+                assert result.raw_card_data[field] == card_data[field]
+
+    def test_v1_0_raw_card_data_matches_input(self):
+        """For v1.0 cards, raw_card_data should match the original input."""
+        card_data = _load_fixture("v1_0", "agentcard.json")
+        verifier = _setup_verifier_with_card(card_data)
+
+        result = verifier.verify_signed_card({"agentCard": card_data})
+        assert result.valid is True
+        assert result.raw_card_data["name"] == card_data["name"]
+        assert result.raw_card_data["supportedInterfaces"] == card_data["supportedInterfaces"]
+
+
+# ---------------------------------------------------------------------------
+# Test: MessageToDict serialization compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestSerializationCompat:
+    """Verify that MessageToDict produces correct output for all schema versions."""
+
+    def test_v0_2_x_card_roundtrips_through_protobuf(self):
+        """A v0.2.x card parsed then serialized must retain all common fields."""
+        card_data = _load_fixture("v0_2_x", "agentcard.json")
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+        output = MessageToDict(card)
+
+        for field in COMMON_FIELDS:
+            if field in card_data and field in output:
+                if field == "skills":
+                    assert len(output["skills"]) == len(card_data["skills"])
+                elif field == "provider":
+                    assert output["provider"]["organization"] == card_data["provider"]["organization"]
+                else:
+                    assert output[field] == card_data[field], f"Field '{field}' mismatch after roundtrip"
+
+    def test_v1_0_card_roundtrips_losslessly(self):
+        """A v1.0 card must roundtrip through ParseDict/MessageToDict without data loss."""
+        card_data = _load_fixture("v1_0", "agentcard.json")
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+        output = MessageToDict(card)
+
+        assert output["name"] == card_data["name"]
+        assert output["version"] == card_data["version"]
+        assert len(output["supportedInterfaces"]) == len(card_data["supportedInterfaces"])
+        assert output["supportedInterfaces"][0]["url"] == card_data["supportedInterfaces"][0]["url"]
+        assert output["provider"]["organization"] == card_data["provider"]["organization"]
+
+    def test_v0_2_x_dropped_fields_not_in_output(self):
+        """Fields dropped by ParseDict must not appear in MessageToDict output."""
+        card_data = _load_fixture("v0_2_x", "agentcard.json")
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+        output = MessageToDict(card)
+
+        for field in V0_2_X_ONLY_FIELDS:
+            assert field not in output, f"Dropped field '{field}' unexpectedly present in MessageToDict output"
+
+
+# ---------------------------------------------------------------------------
+# Test: Cross-version provenance compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestProvenanceCompat:
+    """Verify provenance operations work with cards from all schema versions."""
+
+    @pytest.mark.parametrize(
+        "version_dir,filename",
+        [
+            ("v0_2_x", "agentcard.json"),
+            ("v1_0", "agentcard.json"),
+        ],
+    )
+    def test_create_subject_from_fixture(self, version_dir: str, filename: str):
+        """ProvenanceBuilder.create_subject must work with cards from all versions."""
+        from sigstore_a2a.provenance import ProvenanceBuilder
+
+        card_data = _load_fixture(version_dir, filename)
+        builder = ProvenanceBuilder()
+        subject = builder.create_subject(card_data)
+
+        assert subject.name is not None
+        assert subject.digest.sha256 is not None
+        assert len(subject.digest.sha256) > 0
+
+    @pytest.mark.parametrize(
+        "version_dir,filename",
+        [
+            ("v0_2_x", "agentcard.json"),
+            ("v1_0", "agentcard.json"),
+        ],
+    )
+    def test_create_subject_from_parsed_card(self, version_dir: str, filename: str):
+        """ProvenanceBuilder.create_subject must work with protobuf AgentCard objects."""
+        from sigstore_a2a.provenance import ProvenanceBuilder
+
+        card_data = _load_fixture(version_dir, filename)
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+        builder = ProvenanceBuilder()
+        subject = builder.create_subject(card)
+
+        assert subject.name is not None
+        assert subject.digest.sha256 is not None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,61 +14,69 @@
 
 import pytest
 from a2a.types import AgentCard
-from pydantic import ValidationError
+from google.protobuf.json_format import ParseDict, ParseError
 
 from sigstore_a2a.models.provenance import DigestSet, ProvenanceSubject
 
 
 class TestAgentCard:
-    """Test Agent Card model validation."""
+    """Test Agent Card protobuf parsing."""
 
-    def test_agent_card_validation(self):
-        """Test basic Agent Card validation."""
+    def test_agent_card_parsing(self):
+        """Verify core identity fields survive ParseDict with ignore_unknown_fields."""
         card_data = {
-            "protocolVersion": "0.2.9",
             "name": "Test Agent",
             "description": "A test agent",
-            "url": "https://example.com/agent",
             "version": "1.0.0",
-            "capabilities": {"streaming": True, "pushNotifications": False},
-            "defaultInputModes": ["application/json"],
-            "defaultOutputModes": ["application/json"],
             "skills": [{"id": "test-skill", "name": "Test Skill", "description": "A test skill", "tags": ["test"]}],
         }
 
-        card = AgentCard.model_validate(card_data)
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
         assert card.name == "Test Agent"
         assert card.version == "1.0.0"
         assert len(card.skills) == 1
 
     def test_agent_card_with_provider(self):
-        """Test Agent Card with provider information."""
+        """Verify provider nested message is parsed correctly."""
         card_data = {
-            "protocolVersion": "0.2.9",
             "name": "Test Agent",
             "description": "A test agent",
-            "url": "https://example.com/agent",
             "version": "1.0.0",
             "provider": {"organization": "Test Org", "url": "https://example.com"},
-            "capabilities": {},
+            "skills": [],
+        }
+
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+        assert card.HasField("provider")
+        assert card.provider.organization == "Test Org"
+
+    def test_old_format_card_parsed_with_ignore_unknown_fields(self):
+        """Verify v0.2.x card data is parsed gracefully with unknown fields dropped."""
+        card_data = {
+            "protocolVersion": "0.2.9",
+            "name": "Legacy Agent",
+            "description": "An old-format agent",
+            "url": "https://example.com/agent",
+            "version": "1.0.0",
+            "capabilities": {"streaming": True, "pushNotifications": False},
             "defaultInputModes": ["application/json"],
             "defaultOutputModes": ["application/json"],
             "skills": [],
         }
 
-        card = AgentCard.model_validate(card_data)
-        assert card.provider is not None
-        assert card.provider.organization == "Test Org"
+        card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+        assert card.name == "Legacy Agent"
+        assert card.version == "1.0.0"
 
-    def test_agent_card_missing_required_fields(self):
-        """Test Agent Card validation with missing required fields."""
+    def test_unknown_fields_without_ignore_raises(self):
+        """Verify ParseDict without ignore_unknown_fields raises on unknown fields."""
         card_data = {
-            "name": "Test Agent"
-            # Missing required fields
+            "name": "Test Agent",
+            "unknownField": "should fail",
         }
 
-        with pytest.raises(ValidationError):
-            AgentCard.model_validate(card_data)
+        with pytest.raises(ParseError):
+            ParseDict(card_data, AgentCard(), ignore_unknown_fields=False)
 
 
 class TestProvenance:

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -253,7 +253,7 @@ class TestVerifySignedCard:
         Args:
             card_data: agent card dict (defaults to CARD_DATA)
             dsse_predicate: what the signed DSSE payload predicate contains
-                            (defaults to agent_card.model_dump)
+                            (defaults to MessageToDict(agent_card))
             verify_raises: if set, verify_dsse will raise this exception
         """
         from a2a.types import AgentCard

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -18,7 +18,7 @@ import json
 from unittest.mock import MagicMock
 
 import pytest
-from pydantic import ValidationError
+from google.protobuf.json_format import MessageToDict, ParseDict
 from sigstore.verify.policy import (
     AllOf,
     GitHubWorkflowName,
@@ -35,14 +35,9 @@ from sigstore_a2a.verifier import AgentCardVerifier, IdentityConstraints
 # ---------------------------------------------------------------------------
 
 CARD_DATA = {
-    "protocolVersion": "0.2.9",
     "name": "Test Agent",
     "description": "A test agent",
-    "url": "https://example.com/agent",
     "version": "1.0.0",
-    "capabilities": {"streaming": False, "pushNotifications": False},
-    "defaultInputModes": ["application/json"],
-    "defaultOutputModes": ["application/json"],
     "skills": [
         {
             "id": "test-skill",
@@ -103,9 +98,7 @@ class TestBuildPolicy:
 
     def test_issuer_only_produces_oidc_issuer_policy(self):
         verifier = AgentCardVerifier()
-        constraints = IdentityConstraints(
-            identity_provider="https://accounts.google.com"
-        )
+        constraints = IdentityConstraints(identity_provider="https://accounts.google.com")
         policy = verifier._build_policy(constraints)
         assert isinstance(policy, OIDCIssuer)
 
@@ -176,12 +169,14 @@ class TestExtractVerifiedCard:
         assert card.name == "Test Agent"
         assert card.version == "1.0.0"
 
-    def test_empty_predicate_raises(self):
+    def test_empty_predicate_returns_default_card(self):
+        """Proto3 messages have default values, so an empty dict produces a valid AgentCard."""
         verifier = AgentCardVerifier()
         payload = _make_dsse_payload({})
 
-        with pytest.raises(ValidationError):
-            verifier._extract_verified_card(payload)
+        card = verifier._extract_verified_card(payload)
+        assert card.name == ""
+        assert card.version == ""
 
     def test_missing_predicate_raises(self):
         verifier = AgentCardVerifier()
@@ -245,8 +240,8 @@ class TestVerifySignedCard:
         from a2a.types import AgentCard
 
         data = card_data or CARD_DATA
-        agent_card = AgentCard.model_validate(data)
-        card_json = agent_card.model_dump(by_alias=True, mode="json")
+        agent_card = ParseDict(data, AgentCard(), ignore_unknown_fields=True)
+        card_json = MessageToDict(agent_card)
 
         # Build a mock signed card returned by _parse_signed_card
         mock_signed_card = MagicMock()

--- a/tests/test_verifier.py
+++ b/tests/test_verifier.py
@@ -160,23 +160,42 @@ class TestExtractVerifiedCard:
     authenticated DSSE payload (the source of truth after sigstore
     verification)."""
 
-    def test_valid_payload_returns_agent_card(self):
-        """A valid DSSE payload with a proper predicate should return an AgentCard."""
+    def test_valid_payload_returns_agent_card_and_raw_data(self):
+        """A valid DSSE payload should return both an AgentCard and raw predicate dict."""
         verifier = AgentCardVerifier()
         payload = _make_dsse_payload(CARD_DATA)
 
-        card = verifier._extract_verified_card(payload)
+        card, raw_data = verifier._extract_verified_card(payload)
         assert card.name == "Test Agent"
         assert card.version == "1.0.0"
+        assert raw_data == CARD_DATA
 
     def test_empty_predicate_returns_default_card(self):
         """Proto3 messages have default values, so an empty dict produces a valid AgentCard."""
         verifier = AgentCardVerifier()
         payload = _make_dsse_payload({})
 
-        card = verifier._extract_verified_card(payload)
+        card, raw_data = verifier._extract_verified_card(payload)
         assert card.name == ""
         assert card.version == ""
+        assert raw_data == {}
+
+    def test_old_format_card_preserves_url_in_raw_data(self):
+        """Old v0.2.x cards with url field should preserve it in raw_data for backward compat."""
+        verifier = AgentCardVerifier()
+        old_card = {
+            "name": "Legacy Agent",
+            "url": "https://example.com/agent",
+            "version": "1.0.0",
+            "protocolVersion": "0.2.9",
+            "skills": [],
+        }
+        payload = _make_dsse_payload(old_card)
+
+        card, raw_data = verifier._extract_verified_card(payload)
+        assert card.name == "Legacy Agent"
+        assert raw_data["url"] == "https://example.com/agent"
+        assert raw_data["protocolVersion"] == "0.2.9"
 
     def test_missing_predicate_raises(self):
         verifier = AgentCardVerifier()

--- a/uv.lock
+++ b/uv.lock
@@ -1,24 +1,43 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11"
+resolution-markers = [
+    "python_full_version >= '3.13'",
+    "python_full_version < '3.13'",
+]
 
 [[package]]
 name = "a2a-sdk"
-version = "0.2.16"
+version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "fastapi" },
+    { name = "culsans", marker = "python_full_version < '3.13'" },
+    { name = "google-api-core" },
+    { name = "googleapis-common-protos" },
     { name = "httpx" },
     { name = "httpx-sse" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-sdk" },
+    { name = "json-rpc" },
+    { name = "packaging" },
+    { name = "protobuf" },
     { name = "pydantic" },
-    { name = "sse-starlette" },
-    { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1e/3b/8fd1e3fe28606712c203b968a6fe2c8e7944b6df9e65c28976c66c19286c/a2a_sdk-0.2.16.tar.gz", hash = "sha256:d9638c71674183f32fe12f8865015e91a563a90a3aa9ed43020f1b23164862b3", size = 179006, upload-time = "2025-07-21T19:51:14.107Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/7e/8ac10bbf8b15b16574355f39b17dbdf617a282c27b41c7ff2116e30336df/a2a_sdk-1.1.0.tar.gz", hash = "sha256:e8102dad1b36709dbdc3d19319e38e6dfa3b3a79c30416030eb2d482576be204", size = 375726, upload-time = "2026-05-29T09:34:43.015Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/92/16bfbc2ef0ef037c5860ef3b13e482aeb1860b9643bf833ed522c995f639/a2a_sdk-0.2.16-py3-none-any.whl", hash = "sha256:54782eab3d0ad0d5842bfa07ff78d338ea836f1259ece51a825c53193c67c7d0", size = 103090, upload-time = "2025-07-21T19:51:12.613Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/ea/3a5b160cfd51c67759b08748051094d9365ceff18127633d0021950c9860/a2a_sdk-1.1.0-py3-none-any.whl", hash = "sha256:d7f5846caf18033d8bf3108b11ec827dd8dd32f867c98848ede0e39474be93be", size = 241886, upload-time = "2026-05-29T09:34:41.484Z" },
+]
+
+[[package]]
+name = "aiologic"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sniffio" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/53/a7/809482759f40079f4c4328c7318bf569ae25d457f5017aad30a1b9aafedc/aiologic-0.17.0.tar.gz", hash = "sha256:65aa058e858c94cd208badb188e7f00b54dcabb3ba85b34f794db98074d108b9", size = 251625, upload-time = "2026-06-14T12:24:35.367Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6b/5f75d6194b597ac32bbdbb7b524a28fb1fa98bd0ddcefce94b313a818cc0/aiologic-0.17.0-py3-none-any.whl", hash = "sha256:1bf4d3e4314df2bcb06a9e696417204e206ab50e10ec98d28d157e2e57634f74", size = 161084, upload-time = "2026-06-14T12:24:34.146Z" },
 ]
 
 [[package]]
@@ -260,6 +279,19 @@ wheels = [
 ]
 
 [[package]]
+name = "culsans"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiologic" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/5d/9fb19fb38f6d6120422064279ea5532e22b84aa2be8831d49607194feda3/culsans-0.11.0-py3-none-any.whl", hash = "sha256:278d118f63fc75b9db11b664b436a1b83cc30d9577127848ba41420e66eb5a47", size = 21811, upload-time = "2025-12-31T23:15:37.189Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.7.0"
 source = { registry = "https://pypi.org/simple" }
@@ -305,6 +337,47 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/d9/29/d40217cbe2f6b1359e00c6c307bb3fc876ba74068cbab3dde77f03ca0dc4/ghp-import-2.1.0.tar.gz", hash = "sha256:9c535c4c61193c2df8871222567d7fd7e5014d835f97dc7b7439069e2413d343", size = 10943, upload-time = "2022-05-02T15:47:16.11Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f7/ec/67fbef5d497f86283db54c22eec6f6140243aae73265799baaaa19cd17fb/ghp_import-2.1.0-py3-none-any.whl", hash = "sha256:8337dd7b50877f163d4c0289bc1f1c7f127550241988d568c1db512c4324a619", size = 11034, upload-time = "2022-05-02T15:47:14.552Z" },
+]
+
+[[package]]
+name = "google-api-core"
+version = "2.31.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "google-auth" },
+    { name = "googleapis-common-protos" },
+    { name = "proto-plus" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/22/155cadf1d49272a9cf48f3168c0f3874fa13397297e611a5ea00cd093880/google_api_core-2.31.0.tar.gz", hash = "sha256:2be84ee0f584c48e6bde1b36766e23348b361fb7e55e56135fc76ce1c397f9c2", size = 176492, upload-time = "2026-06-03T14:52:17.257Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/86/40/9bdbb60b03a332bd45acb8703da08bbc27d991d35286b62e42acc86d243a/google_api_core-2.31.0-py3-none-any.whl", hash = "sha256:ef79fb3784c71cbac89cbd03301ba0c8fb8ad2aa95d7f9204dd9628f7adf59ab", size = 173102, upload-time = "2026-06-03T14:51:26.729Z" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.55.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/6f/f3f4ac177c67bbee8fe8e88f2ab4f36af88c44a096e165c5217accf6e5d3/google_auth-2.55.1.tar.gz", hash = "sha256:fb2d9b730f2c9b8d326ec8d7222f21aef2ead15bf0513793d6442485d87af0a1", size = 349527, upload-time = "2026-06-25T23:39:27.182Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/1d/f6d3ca1ad0725f2e08a1c6915640748a52de2e66596160a4d53b010cccf0/google_auth-2.55.1-py3-none-any.whl", hash = "sha256:eada68dfd52b3b81191827601e2a0c3fa12540c818534b630ddc5355769c3995", size = 252349, upload-time = "2026-06-25T23:38:52.946Z" },
+]
+
+[[package]]
+name = "googleapis-common-protos"
+version = "1.75.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
 ]
 
 [[package]]
@@ -387,18 +460,6 @@ wheels = [
 ]
 
 [[package]]
-name = "importlib-metadata"
-version = "8.7.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "zipp" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/76/66/650a33bd90f786193e4de4b3ad86ea60b53c89b669a5c7be931fac31cdb0/importlib_metadata-8.7.0.tar.gz", hash = "sha256:d13b81ad223b890aa16c5471f2ac3056cf76c5f10f82d6f9292f0b415f389000", size = 56641, upload-time = "2025-04-27T15:29:01.736Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/b0/36bd937216ec521246249be3bf9855081de4c5e06a0c9b4219dbeda50373/importlib_metadata-8.7.0-py3-none-any.whl", hash = "sha256:e5dd1551894c77868a30651cef00984d50e1002d06942a7101d34870c5f02afd", size = 27656, upload-time = "2025-04-27T15:29:00.214Z" },
-]
-
-[[package]]
 name = "iniconfig"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -417,6 +478,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/df/bf/f7da0350254c0ed7c72f3e33cef02e048281fec7ecec5f032d4aac52226b/jinja2-3.1.6.tar.gz", hash = "sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d", size = 245115, upload-time = "2025-03-05T20:05:02.478Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/62/a1/3d680cbfd5f4b8f15abc1d571870c5fc3e594bb582bc3b64ea099db13e56/jinja2-3.1.6-py3-none-any.whl", hash = "sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67", size = 134899, upload-time = "2025-03-05T20:05:00.369Z" },
+]
+
+[[package]]
+name = "json-rpc"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/9e/59f4a5b7855ced7346ebf40a2e9a8942863f644378d956f68bcef2c88b90/json-rpc-1.15.0.tar.gz", hash = "sha256:e6441d56c1dcd54241c937d0a2dcd193bdf0bdc539b5316524713f554b7f85b9", size = 28854, upload-time = "2023-06-11T09:45:49.078Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/94/9e/820c4b086ad01ba7d77369fb8b11470a01fac9b4977f02e18659cf378b6b/json_rpc-1.15.0-py2.py3-none-any.whl", hash = "sha256:4a4668bbbe7116feb4abbd0f54e64a4adcf4b8f648f19ffa0848ad0f6606a9bf", size = 39450, upload-time = "2023-06-11T09:45:47.136Z" },
 ]
 
 [[package]]
@@ -693,46 +763,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opentelemetry-api"
-version = "1.35.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "importlib-metadata" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/99/c9/4509bfca6bb43220ce7f863c9f791e0d5001c2ec2b5867d48586008b3d96/opentelemetry_api-1.35.0.tar.gz", hash = "sha256:a111b959bcfa5b4d7dffc2fbd6a241aa72dd78dd8e79b5b1662bda896c5d2ffe", size = 64778, upload-time = "2025-07-11T12:23:28.804Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1d/5a/3f8d078dbf55d18442f6a2ecedf6786d81d7245844b2b20ce2b8ad6f0307/opentelemetry_api-1.35.0-py3-none-any.whl", hash = "sha256:c4ea7e258a244858daf18474625e9cc0149b8ee354f37843415771a40c25ee06", size = 65566, upload-time = "2025-07-11T12:23:07.944Z" },
-]
-
-[[package]]
-name = "opentelemetry-sdk"
-version = "1.35.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-semantic-conventions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/9a/cf/1eb2ed2ce55e0a9aa95b3007f26f55c7943aeef0a783bb006bdd92b3299e/opentelemetry_sdk-1.35.0.tar.gz", hash = "sha256:2a400b415ab68aaa6f04e8a6a9f6552908fb3090ae2ff78d6ae0c597ac581954", size = 160871, upload-time = "2025-07-11T12:23:39.566Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/01/4f/8e32b757ef3b660511b638ab52d1ed9259b666bdeeceba51a082ce3aea95/opentelemetry_sdk-1.35.0-py3-none-any.whl", hash = "sha256:223d9e5f5678518f4842311bb73966e0b6db5d1e0b74e35074c052cd2487f800", size = 119379, upload-time = "2025-07-11T12:23:24.521Z" },
-]
-
-[[package]]
-name = "opentelemetry-semantic-conventions"
-version = "0.56b0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "opentelemetry-api" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/32/8e/214fa817f63b9f068519463d8ab46afd5d03b98930c39394a37ae3e741d0/opentelemetry_semantic_conventions-0.56b0.tar.gz", hash = "sha256:c114c2eacc8ff6d3908cb328c811eaf64e6d68623840be9224dc829c4fd6c2ea", size = 124221, upload-time = "2025-07-11T12:23:40.71Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/3f/e80c1b017066a9d999efffe88d1cce66116dcf5cb7f80c41040a83b6e03b/opentelemetry_semantic_conventions-0.56b0-py3-none-any.whl", hash = "sha256:df44492868fd6b482511cc43a942e7194be64e94945f572db24df2e279a001a2", size = 201625, upload-time = "2025-07-11T12:23:25.63Z" },
-]
-
-[[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
@@ -778,12 +808,51 @@ wheels = [
 ]
 
 [[package]]
+name = "proto-plus"
+version = "1.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/56/e647b0c675392d2da368da7b6f158f7368b18542fd6f7d7400a2f39de000/proto_plus-1.28.0.tar.gz", hash = "sha256:38e5696342835b08fc116f30a25665b29531cda9d5d5643e9b81fc312385abd9", size = 57221, upload-time = "2026-05-07T08:04:50.811Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7c/20/b122d4626976acb81132036d2ad1bb35a1a8775fceb837ec30964622516a/proto_plus-1.28.0-py3-none-any.whl", hash = "sha256:a630604310899e73c59ec302e5765c058d412b2f090b9c79c8822589f14955b8", size = 50410, upload-time = "2026-05-07T08:03:31.962Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
+]
+
+[[package]]
 name = "pyasn1"
 version = "0.6.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ba/e9/01f1a64245b89f039897cb0130016d79f77d52669aae6ee7b159a6c4c018/pyasn1-0.6.1.tar.gz", hash = "sha256:6f580d2bdd84365380830acf45550f2511469f673cb4a5ae3857a3170128b034", size = 145322, upload-time = "2024-09-10T22:41:42.55Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/f1/d6a797abb14f6283c0ddff96bbdd46937f64122b8c925cab503dd37f8214/pyasn1-0.6.1-py3-none-any.whl", hash = "sha256:0d632f46f2ba09143da3a8afe9e33fb6f92fa2320ab7e886e2d0f7672af84629", size = 83135, upload-time = "2024-09-11T16:00:36.122Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
 ]
 
 [[package]]
@@ -1065,7 +1134,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -1073,9 +1142,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e1/0a/929373653770d8a0d7ea76c37de6e41f11eb07559b103b1c02cafb3f7cf8/requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422", size = 135258, upload-time = "2025-06-09T16:43:07.34Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7c/e4/56027c4a6b4ae70ca9de302488c5ca95ad4a39e190093d6c1a8ace08341b/requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c", size = 64847, upload-time = "2025-06-09T16:43:05.728Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1191,6 +1260,7 @@ dependencies = [
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "httpx" },
+    { name = "protobuf" },
     { name = "pydantic" },
     { name = "rich" },
     { name = "sigstore" },
@@ -1214,11 +1284,12 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "a2a-sdk", specifier = ">=0.2.16" },
+    { name = "a2a-sdk", specifier = ">=1.0.0,<2.0.0" },
     { name = "click", specifier = ">=8.0.0" },
     { name = "cryptography", specifier = ">=41.0.0" },
     { name = "fastapi", specifier = ">=0.100.0" },
     { name = "httpx", specifier = ">=0.24.0" },
+    { name = "protobuf", specifier = ">=4.0.0" },
     { name = "pydantic", specifier = ">=2.0.0,<3.0.0" },
     { name = "rich", specifier = ">=13.0.0" },
     { name = "sigstore", specifier = ">=4.2.0" },
@@ -1281,18 +1352,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
-]
-
-[[package]]
-name = "sse-starlette"
-version = "3.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "anyio" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/f2/bd/357d6183ed3a71143747c974a3a83d4a546f290c20e66006988f8a662842/sse_starlette-3.0.0.tar.gz", hash = "sha256:5318b0bf5aaa23550c9dd88bd3b8c9c2664aa3f94232ccde5e87519244dbc6b8", size = 21044, upload-time = "2025-07-26T10:24:10.758Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/f2/92ff9d1cca5fc97bf3407f817a571e02a55b080ec5f4a6f8df325ffbff80/sse_starlette-3.0.0-py3-none-any.whl", hash = "sha256:43ea0a032f936b3efff683aba55aa235e91b067ee9283beee918d2acce4fbb67", size = 11307, upload-time = "2025-07-26T10:24:09.605Z" },
 ]
 
 [[package]]
@@ -1404,10 +1463,76 @@ wheels = [
 ]
 
 [[package]]
-name = "zipp"
-version = "3.23.0"
+name = "wrapt"
+version = "2.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/a4/282c8e64300a59fc834518a54bf0afabb4ff9218b5fa76958b450459a844/wrapt-2.2.2.tar.gz", hash = "sha256:0788e321027c999bf221b667bd4a54aaefd1a36283749a860ac3eb77daed0302", size = 129068, upload-time = "2026-06-20T23:49:44.49Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
+    { url = "https://files.pythonhosted.org/packages/27/15/0c2d55168707465abfc41f33c0b23d792a5fa9b65c26983606940900a120/wrapt-2.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f1a2ff355ece6a111ca7a20dc86df6659c9205d3fcee674ca34f2a2854fd4e73", size = 80782, upload-time = "2026-06-20T23:47:44.367Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/b5/5c0b093eb48f8a062ef6267d3cb36e9bb1b88440181f6545a383c60efdf8/wrapt-2.2.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:55b9a899e6fff5444f229d30aa6e9ac92d2216d9d60f33c771b5d76a760d5f8e", size = 81678, upload-time = "2026-06-20T23:47:45.857Z" },
+    { url = "https://files.pythonhosted.org/packages/34/f3/de70937472dd3e8a4e6811192f9c6075efdffd4a2cd9b4596bf160f89668/wrapt-2.2.2-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:a2d78c363f97d8bd718ee40432c66395685e9e98528ccaa423c3355d1715a26d", size = 159671, upload-time = "2026-06-20T23:47:47.345Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ec/40aed2330e7f02ecf74386ffcfef9ccb7108c6a430f15b6a252b663b1bed/wrapt-2.2.2-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d619e1eed9bd4f6ed9f24cd61971aa086fa86505289628d464bcf8a2c2e3f328", size = 160785, upload-time = "2026-06-20T23:47:48.759Z" },
+    { url = "https://files.pythonhosted.org/packages/45/04/aa5309beed5344b00220ae6b3b24055852192656194c27947bee1736306a/wrapt-2.2.2-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:518b0c5e323511ec56a38894802ddd5e1222626484e68efe63f201854ad788e5", size = 153699, upload-time = "2026-06-20T23:47:50.177Z" },
+    { url = "https://files.pythonhosted.org/packages/01/df/2def7e99d1fe87eea413f95f671924cdddcb08823b1ffd212748dfa6d062/wrapt-2.2.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:4bccea5cdecffa9dd70e343741f0e41e0a16619313d04b72f78bb525162ebcd0", size = 159695, upload-time = "2026-06-20T23:47:51.602Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/f6/a906d01a2ce12157bad2404957b3e2140da354b8a70b2fa48bbf282871c0/wrapt-2.2.2-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:209112cafd963710a05d199aae431d79a28bc76eb8e6d1bbbb8ad24340722cae", size = 152813, upload-time = "2026-06-20T23:47:53.03Z" },
+    { url = "https://files.pythonhosted.org/packages/02/49/bc0086292d239575b4c08f4cf8a4079fa58abbad58ec23abf84833a283ed/wrapt-2.2.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:e5a5290e4bf2f332fc29ce72ffb9a2fff678aaac047e2e9f5f7165cd7792e099", size = 158809, upload-time = "2026-06-20T23:47:54.391Z" },
+    { url = "https://files.pythonhosted.org/packages/55/83/8fbd034de1f3e907edaa18786d5dd8f6932874edee0826c7cecb5cab03a1/wrapt-2.2.2-cp311-cp311-win32.whl", hash = "sha256:5499236ad1dc116012e2a5dd943f3f31af12fce452128e2bbcbd55a7d3d4d14c", size = 77414, upload-time = "2026-06-20T23:47:55.882Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/9c/23695baa331c6de4e874c3d78b8e0bed92e1d2a274e665b29858f6841672/wrapt-2.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8636809939152be6ae20a6cef0fed9fe60f411b47847d0426a826884b469e971", size = 80368, upload-time = "2026-06-20T23:47:57.237Z" },
+    { url = "https://files.pythonhosted.org/packages/08/49/40cefc342bf89b234a4490d741290fce781774b831aefb39c25471da96c9/wrapt-2.2.2-cp311-cp311-win_arm64.whl", hash = "sha256:5d0a142f7af07caeb5e5da87493162a7b8efa19ba919e550a746f7446e13fb30", size = 79489, upload-time = "2026-06-20T23:47:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/85/180b40628b23772692a0c76e8030114e1c0ae068470ed531919f0a5f2a4a/wrapt-2.2.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8417fd3c674d3c8023d080292d29301531a12daf8bd938dd419710dd2f464f2b", size = 81484, upload-time = "2026-06-20T23:47:59.924Z" },
+    { url = "https://files.pythonhosted.org/packages/94/f2/21c90f2a16689702e2aaff45795b11018dff2c9b1242bac10d225483f676/wrapt-2.2.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e7070c7472582e31af3dfc2622b2381a0df7435110a9388ed8db5ffbce67efb", size = 82151, upload-time = "2026-06-20T23:48:01.303Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/b3/7e6e9fcf4fe7e1b69a49fe6cc5a44e8224bab6283c5233c97e132f14908e/wrapt-2.2.2-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2e096c9d39a59b35b63c9aacfbbbec2088ff51ff1fc31051acc60a07f42f273a", size = 169828, upload-time = "2026-06-20T23:48:02.719Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/43/894f132d857ed5a9904d937baf368badcbe5ea9e436e2f1930fe21c9f1f0/wrapt-2.2.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6d1a6050405bf334be33bf66296f113563622972a34900ae6fa60fd283a1a900", size = 171544, upload-time = "2026-06-20T23:48:04.266Z" },
+    { url = "https://files.pythonhosted.org/packages/29/de/3c833e03725b477e9ea34028224dd21a48781830101e4e036f77e8b6b102/wrapt-2.2.2-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:10adb01371408c6de504a6658b9886480f1a4919a83752748a387a504a21df79", size = 160663, upload-time = "2026-06-20T23:48:05.708Z" },
+    { url = "https://files.pythonhosted.org/packages/33/be/27edce350b24e3054d9d047f65f16d4c4d4c1f3f31c4278a1f8a95c723c8/wrapt-2.2.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3442eee2a5798f9b451f1b2cd7518ce8b7e28a2a364696c414460a0e295c012a", size = 169387, upload-time = "2026-06-20T23:48:07.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c4/9fd9679af8bf38e146652c7f47b6b352c3e5795b4ad1c0b7f94e15ac2aa7/wrapt-2.2.2-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:6c99012a22f735a85eed7c4b86a3e99c30fdd57d9e115b2b45f796264b58d0bf", size = 158849, upload-time = "2026-06-20T23:48:08.91Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/c2/aa6c0c2206803068c6859dabe01f8c84c43744da93d4c67b8946d21655ee/wrapt-2.2.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3b686cfc008776a3952d6213cb296ed7f45d782a8453936406faa89eac0835ab", size = 168147, upload-time = "2026-06-20T23:48:10.374Z" },
+    { url = "https://files.pythonhosted.org/packages/42/63/3eb25da41049d20ae18fcab2dd8b056e02387c4bfa626cbdfb7c3b872e4f/wrapt-2.2.2-cp312-cp312-win32.whl", hash = "sha256:ef2cce266b5b0b07e19fa82e59673b81142b7a3607c8ed1254113d048ed668da", size = 77734, upload-time = "2026-06-20T23:48:11.769Z" },
+    { url = "https://files.pythonhosted.org/packages/da/09/0390e008a305360948fa9ce69507d041ac12cb2ee5d28e34467e2ee79391/wrapt-2.2.2-cp312-cp312-win_amd64.whl", hash = "sha256:abf8c20a2d72ee69e16328b3c91342c446e723bfe48bfcc4dded3b9722ac027f", size = 80585, upload-time = "2026-06-20T23:48:13.117Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b3/84c445c66969f2d3457276b183a48c91097d59bbef9af6c075366b0f8c36/wrapt-2.2.2-cp312-cp312-win_arm64.whl", hash = "sha256:c6c64c5d02578bc4c4bca4f0aef1504de933c1d5b4ac2710b9131111459506c8", size = 79553, upload-time = "2026-06-20T23:48:14.5Z" },
+    { url = "https://files.pythonhosted.org/packages/43/fc/f32f4b22c6511173c11d9e541ab4e7d8467a0f1b3455acaf784115d31ff8/wrapt-2.2.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:9e8b648270c613720a202d9a45ebabc33261b22c3a839b115ac5bce8c0bb0d69", size = 81296, upload-time = "2026-06-20T23:48:15.881Z" },
+    { url = "https://files.pythonhosted.org/packages/72/06/4d117d5d77a9344776c0248b24dae3d3dd2f58e5f765fa08cf887072e719/wrapt-2.2.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6fb7e94e8fe3e4c3067bb1653a91cce7c5e83acc119fdd41501b1bf74654617", size = 81841, upload-time = "2026-06-20T23:48:17.262Z" },
+    { url = "https://files.pythonhosted.org/packages/15/ff/63ad96f98eb58a742b1a20d80f21da88924405910149950b912368150468/wrapt-2.2.2-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fb18fc51e813df0d9c98049e3bf2298a5495a648602040e21fa3c7329371159e", size = 167882, upload-time = "2026-06-20T23:48:18.764Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1f/8bb62d8933df7acf3247194e6e9fc68edf9d2fa203252c89c94b319dd472/wrapt-2.2.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:94b00b00f806eb3ef2abe9049ed45994a81ee9284884d96e6b8314927c6cea3d", size = 167411, upload-time = "2026-06-20T23:48:20.315Z" },
+    { url = "https://files.pythonhosted.org/packages/17/09/8789dcb09ee1de715727db7521aabbb68ffa68dfade3a49468440cfced49/wrapt-2.2.2-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:62415fd095bc590b842b6d092f2b5d9ccbaeb7e0b28535c03dcea2718b48636b", size = 158607, upload-time = "2026-06-20T23:48:21.728Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/20/66e02562d53ee67d841f175e38e3c993c2d78a3e104c576cad61c028b43c/wrapt-2.2.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a41e758d80dc0ab8c210f641ac892009d356cf1f955d97db544c8dd317b4d14c", size = 166367, upload-time = "2026-06-20T23:48:23.177Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a3/832ac4e41222fb263b3042d42c2f08d305db7d0f0c9b1d3a271a9eede8f6/wrapt-2.2.2-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:b84cd4058001c9727b0e9980b7a9e66325b5ca748b1b578e822cade1bc6b304f", size = 157176, upload-time = "2026-06-20T23:48:24.711Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/01/1bd5e4d2df9c0178989ac8da9186543465388588ee2ef153e2591accebef/wrapt-2.2.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:26fc73a1b15e0946d2942b9a4426d162b51676338327dc067ccd8d2d76385f94", size = 167025, upload-time = "2026-06-20T23:48:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/69/583ed25291ab53e1ec117135fb1c33425e2f46d2bc8f29c17f7a94cf4274/wrapt-2.2.2-cp313-cp313-win32.whl", hash = "sha256:3c4095803491f6ef72128914c28ec05bbad9758433bb35f6715a3e9c8e46fb2d", size = 77605, upload-time = "2026-06-20T23:48:27.643Z" },
+    { url = "https://files.pythonhosted.org/packages/29/68/e69fc6d06e1523c68e0d00f95c9aed1158ce9908ee41603f7f2eae3d5db6/wrapt-2.2.2-cp313-cp313-win_amd64.whl", hash = "sha256:2cb07f414fab25dbe6b5c7398e1491423a5c81a6209533639969a6c928d474a4", size = 80508, upload-time = "2026-06-20T23:48:29.013Z" },
+    { url = "https://files.pythonhosted.org/packages/55/21/fe7a393d9e5dc0923bed8f5d857e9dcff210f1fa0888c02cc8f3ffaa55aa/wrapt-2.2.2-cp313-cp313-win_arm64.whl", hash = "sha256:1fc7691f070220215cccb2a20836b9adbaecb8ff22ad47abe63de5f110994fac", size = 79565, upload-time = "2026-06-20T23:48:30.429Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/e5/c120d13bf5091164f68c3c1657e84f16f57e71d978421b626393ac5bd7eb/wrapt-2.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ec8f83949028366531383603139403cac7a826e4011955813cdd640017845ce5", size = 83264, upload-time = "2026-06-20T23:48:31.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b0/d4a1eb97e0e286625bdf21bc7f702637f9607787ffbbdb5ec14d50c79dbf/wrapt-2.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:4b481fb0c40d9fd90a5809911208da700987d373a20a4709dc9e3944af7a6bec", size = 83791, upload-time = "2026-06-20T23:48:33.482Z" },
+    { url = "https://files.pythonhosted.org/packages/18/1e/f060df47755e87b57684cee7bfc1362b204df55fac96ffebc0631b697b79/wrapt-2.2.2-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0065a3b657cec06813b4241d2462ccec287f6863103d7445b725fb3a889736f9", size = 203399, upload-time = "2026-06-20T23:48:34.97Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/de/2316a757a1abb6453700b79d83e532146dcef2611348282d4d8889792161/wrapt-2.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:30f7424af5c5c345b7f26490e097f74a2ef45b3d08b664dc33571aee3bd3b56c", size = 210461, upload-time = "2026-06-20T23:48:36.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/29/d1160785ae18ca2495a6d82a21154103d74f656c9fd457fb35f6b11b965a/wrapt-2.2.2-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07fdcb012821859168641acf68afad61ef9783cf37100af85f152550e9677194", size = 195313, upload-time = "2026-06-20T23:48:38.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/2d/7caa9598ae61a9cf0989cc501739cbeeb7d650ab3193cca1407b9af0c6ab/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:f90038ab58fafb584801ca62d72384d7d5225d93c76f7b773c22fae545bd8066", size = 206116, upload-time = "2026-06-20T23:48:39.804Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/02/281ea1088b8650d865f311b35cf86fd21df89128e2909714f1161e01c9d0/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:c5d7825491bfa2d08b97e9557768987952c7b9ae687d06c3320b40a37ccb7f20", size = 192668, upload-time = "2026-06-20T23:48:41.346Z" },
+    { url = "https://files.pythonhosted.org/packages/be/7d/976e2d5b4b5c5babda40974edd54d0a5585cb60132ed86b46f4b80239b16/wrapt-2.2.2-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:0ad520e6daa9bbf136f14de735474dbec7dcc0891f718e1d274ce8dc92e645af", size = 198891, upload-time = "2026-06-20T23:48:43.056Z" },
+    { url = "https://files.pythonhosted.org/packages/59/b7/e47651797c097f75a37e2ce86dcf04048ff576f3a674f7c558df7b5e9622/wrapt-2.2.2-cp313-cp313t-win32.whl", hash = "sha256:25904acb9475f46c24fe0423dbc8fda8cc5fbc282ab3dc6e72e919748c53f4e9", size = 78537, upload-time = "2026-06-20T23:48:44.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/6f/9fa5d59fb06d890defb5a8f727ce6a14d2932c8760153f96956628559fee/wrapt-2.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:305d4c247d61c4115794a169141823c62f719525ddb90b23aa332741c77d2c28", size = 82005, upload-time = "2026-06-20T23:48:46.391Z" },
+    { url = "https://files.pythonhosted.org/packages/15/80/4c7bd9873d1f9f7d138d93556b500469dbe24f42710b877519c2b9eb380d/wrapt-2.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:c20279cd1a29800815d7b2d6338b60a6c6e78263f9d6e62e0eda251ba9cae2d0", size = 80762, upload-time = "2026-06-20T23:48:47.964Z" },
+    { url = "https://files.pythonhosted.org/packages/24/05/7fd9c3f83b2c74cbfc572a0b88aa37431e04bd8aed70d2c0efd3464206de/wrapt-2.2.2-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:0e64826f920c42d9d9f87e8cc09ffae66c51ede12d59061a5a426deb9aa71745", size = 81341, upload-time = "2026-06-20T23:48:49.39Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/68/1bfa43100dd90d4ef74a05897b86275cf57e1313ca14aae2545bc9f872c9/wrapt-2.2.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:dcaa5e1451bd8751d7bd1568dfa3321c78092a52a7ecb5d1a0f18a5791e1fd00", size = 81921, upload-time = "2026-06-20T23:48:50.986Z" },
+    { url = "https://files.pythonhosted.org/packages/74/eb/df7b7f0b631dbbc750f39be27d8b55f65777d8ac86da80e12be41a644c4b/wrapt-2.2.2-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:0abfd648dac9ac9c5b3aa9b523d27f1789046640b58dcd5652a720ddb325e1fc", size = 167713, upload-time = "2026-06-20T23:48:52.598Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/9a/d1bd36f6d088c8e652a9383cabbd49af30b8c576302a7eccddbab6963e3f/wrapt-2.2.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f4bfd8d1eb438153eff8b8cfe87f032ba65731e1ce06138b5090f745a33f6f95", size = 166779, upload-time = "2026-06-20T23:48:54.33Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ae/24ffacd4187fac2740a1972093929e836dea092d42c87d728cd98fee11a6/wrapt-2.2.2-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c427c9d06d859848a69f0d928fe28b5c33a941b2265d10a0e1f15cd244f1ee33", size = 158407, upload-time = "2026-06-20T23:48:55.944Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/ed/974427668249a356051e8d67d47fa54ef6c777f0fcf3bae9d292c047d4b6/wrapt-2.2.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4250b43d1a129d947e083c4dc6baf333c9bb34edd26f912d5b0457841fc858ab", size = 166594, upload-time = "2026-06-20T23:48:57.617Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/5f/e1d7c6e4523f78db2fbd7826babd0348da1d5e0834c4f918b9ab5757dfae/wrapt-2.2.2-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:173e5bb5ca350a6e0abab60b7ec7cdd7992a814cb14b4de670a28f067f105663", size = 157068, upload-time = "2026-06-20T23:48:59.171Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/c1/7ebd1027f00700c0b0233b20aceef2b4784294ed64971424c4a78e069e34/wrapt-2.2.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:aa14b01804bce36c6d63d7b6a4f55df390f29f8648cc13a1f40b166f4d54680d", size = 166470, upload-time = "2026-06-20T23:49:00.737Z" },
+    { url = "https://files.pythonhosted.org/packages/99/eb/974e471a6a978b8180186b8a9dc5ae3361ce269a967190b709b8ce17abfb/wrapt-2.2.2-cp314-cp314-win32.whl", hash = "sha256:58f9f8d637c9a6e245c6ef5b109b67ec187d2faed23d1405656b51d96e0a5b56", size = 78062, upload-time = "2026-06-20T23:49:02.327Z" },
+    { url = "https://files.pythonhosted.org/packages/49/ec/e1281156cdc7a66693838ad7a0865ad641c74abd337a957d668b575aaffb/wrapt-2.2.2-cp314-cp314-win_amd64.whl", hash = "sha256:385cb1866f20479e83299af585375bfa0a4b0c6c9907a981483ea782ea8ae406", size = 80832, upload-time = "2026-06-20T23:49:03.837Z" },
+    { url = "https://files.pythonhosted.org/packages/45/7d/1b6b5ddd94005a2dac97a4490c9838f3154977850d633abcb65b30089437/wrapt-2.2.2-cp314-cp314-win_arm64.whl", hash = "sha256:8ffbeaea6771a6eba6e6eeb09767864995726bc8240bb54baf88a9bb1db34d5c", size = 80029, upload-time = "2026-06-20T23:49:05.237Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/33/9ebcf8aafe91c601127cbd93708c16aa8f688f34a10bf004046803ecdc4f/wrapt-2.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:09f811d43f6f33ec7515f0be76b159569f4057ab54d3e079c3204dddb90afa2a", size = 83357, upload-time = "2026-06-20T23:49:06.632Z" },
+    { url = "https://files.pythonhosted.org/packages/39/38/ec45b635153327b52e52732a0ea980e5f00b7efba65f9e018828f1e69daa/wrapt-2.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a795d3c06e5fbf9ea2f13196180b77aeab1b4685917256ee0d014cc163d90063", size = 83794, upload-time = "2026-06-20T23:49:08.098Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/ea/1a89e6d3b7a83c3affe5c09cde77792c947e63e4bc85ad84cd5bb9abb0d8/wrapt-2.2.2-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:45c2f2768e790c9f8db90f239ef23a2af8e7570f25a35619ef902df4a738447f", size = 203362, upload-time = "2026-06-20T23:49:09.811Z" },
+    { url = "https://files.pythonhosted.org/packages/19/d8/3b58763d9863b5a73771c0d97110f9595d248db454009e07e1535ee905a4/wrapt-2.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbf00ee0cb55ec24e2b0995a71942b85b21a066db8f3f46e1dbfdb9433ffba81", size = 210449, upload-time = "2026-06-20T23:49:11.521Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/6f/17fd9e053103d8be148d20d5d7505facc72d5fe1f9127973904ceaed79cf/wrapt-2.2.2-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:2252f77663651b89255895f58cc6ac08fcb206d4371813e5af61bb62d4f7689c", size = 195349, upload-time = "2026-06-20T23:49:13.346Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/d0d1ccaaa12cb7dccf28a23f0279a608ba498f71e81d949d5ed54bcfd5c1/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:2cd7181ab1c31192ff5219269830744b5a62020b3a6d433588c4f1c95b8f8bff", size = 206099, upload-time = "2026-06-20T23:49:15.051Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b3/e8aa07b619890a2aa6cde1931b1887abb08820721b564a5f80b7ca3f3aa0/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:6fe35fd51b74867d8b80174c277bd6bbf6a73e443f908129dc531c4b688a20d5", size = 192728, upload-time = "2026-06-20T23:49:16.854Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/f0/1819fb50f0d3c9bd758d8a83b56f1b470dee8b5b8eac8702b7c137cea9d4/wrapt-2.2.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:11d95fc2fbad3163596c39d440e6f21ca9fccece74b56e30a37ac2fca786a07c", size = 198842, upload-time = "2026-06-20T23:49:18.504Z" },
+    { url = "https://files.pythonhosted.org/packages/67/7c/e88313f16a99930b899ef970d91c281544a470749a359decad994483bbda/wrapt-2.2.2-cp314-cp314t-win32.whl", hash = "sha256:d8a15813215f33fa83667bfc978b300e35669ea8bb424e970a1426bcb7bc6cca", size = 79059, upload-time = "2026-06-20T23:49:20.107Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/4f/ac12fda57a55068a094ec42851fb0a40e8489d8941863d517452de62e507/wrapt-2.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:d09db0f7e8357060d3c38fc22a018aba683a796bf184360fd1a58f6fc180dc77", size = 82462, upload-time = "2026-06-20T23:49:21.631Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/df732dac86d9b2027c56bd163dbc883e037b16c3469614752e148d219c61/wrapt-2.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:f32fe639c39561ccc187bcae17e9271be0eb45f1c2952510d2f29b33ab577347", size = 81182, upload-time = "2026-06-20T23:49:23.199Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/d2/6317eb6d4554855bbf12d61857774af34747bf88a42c19bf306de67e2fa3/wrapt-2.2.2-py3-none-any.whl", hash = "sha256:5bad217350f19ce99ca5b5e71d406765ea86fe541628426772b657375ee1c048", size = 61460, upload-time = "2026-06-20T23:49:42.966Z" },
 ]


### PR DESCRIPTION


<!-- Thanks for opening a pull request! Please do not just delete this text. -->

#### Summary
<!--
 Explain the **motivation** for making this change. What existing problem does the pull request solve? How can reviewers test this PR?

Please remember to:
- Pair the PR with an issue. If it is a new feature, the issue should proceed the PR and will have allowed sufficent time for discussions to take place. Pleases use
issue tags such as "Closes #XYZ" or "Resolves sigstore/repo-name#XYZ".
  [documentation](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword)
- ensure your commits are signed-off, as sigstore uses the [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin) using `git commit -s`, or `git commit -s --amend` if you want to amend already existing commits

Thank you :)
-->


- Replace all Pydantic-specific `AgentCard` usage (`model_validate()`, `model_dump()`) with protobuf equivalents (`ParseDict()`, `MessageToDict()`)
- Add custom Pydantic validator/serializer to `SignedAgentCard` for protobuf `AgentCard` field handling with `arbitrary_types_allowed=True`
- Update `url` property to use `supported_interfaces` (v1.0 schema change)
- Update `a2a-sdk` dependency to `>=1.0.0,<2.0.0` with explicit `protobuf` dependency
- Use `ignore_unknown_fields=True` in `ParseDict` for backward compatibility with v0.2.x signed cards
- Preserve raw DSSE predicate dict in `VerificationResult` so legacy fields (`url`, `protocolVersion`) remain accessible after verification
- Fix CLI `verify` command to handle both v0.2.x (`url`) and v1.0 (`supportedInterfaces`) card formats
- Add historic compatibility test suite (`tests/test_compat.py`) with versioned fixtures under `tests/historic/` covering ParseDict, SignedAgentCard, verification flow, serialization roundtrip, and provenance across schema versions
- Replace `extremely-dangerous-public-oidc-beacon` GitHub Action with GCS-hosted testing token for more reliable CI signing/verification

Closes https://github.com/sigstore/sigstore-a2a/issues/69

##### Checklist

- [ ] All commits are signed-off, using [DCO](https://en.wikipedia.org/wiki/Developer_Certificate_of_Origin)
- [ ] All new code has docstrings and type annotations
- [ ] Public facing changes are paired with documentation changes
- [ ] Release note has been added to CHANGELOG.md if needed
