### PR TITLE
ci: add Python 3.14 to test matrix

### DIFF
--- a/.github/workflows/test-matrix.yml
+++ b/.github/workflows/test-matrix.yml
@@ -22,13 +22,14 @@ permissions:
   contents: read
 
 jobs:
-  test-python-versions:
-    name: Python ${{ matrix.python-version }} (Linux)
-    runs-on: ubuntu-latest
+  test:
+    name: Python ${{ matrix.python-version }} (${{ matrix.os == 'ubuntu-latest' && 'Linux' || matrix.os == 'macos-latest' && 'macOS' || 'Windows' }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
+        os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
       - name: Checkout repository
@@ -44,10 +45,20 @@ jobs:
         with:
           version: "latest"
 
-      - name: Cache UV dependencies
+      - name: Cache UV dependencies (Unix)
+        if: runner.os != 'Windows'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/uv
+          key: ${{ runner.os }}-uv-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-uv-py${{ matrix.python-version }}-
+
+      - name: Cache UV dependencies (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~\AppData\Local\uv\cache
           key: ${{ runner.os }}-uv-py${{ matrix.python-version }}-${{ hashFiles('uv.lock') }}
           restore-keys: |
             ${{ runner.os }}-uv-py${{ matrix.python-version }}-
@@ -59,57 +70,11 @@ jobs:
         run: make test
 
       - name: Upload coverage
-        if: matrix.python-version == '3.13'
+        if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           file: ./coverage.xml
           fail_ci_if_error: false
-
-  test-platforms:
-    name: Python 3.13 (${{ matrix.os == 'macos-latest' && 'macOS' || 'Windows' }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [macos-latest, windows-latest]
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-
-      - name: Set up Python
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: '3.13'
-
-      - name: Install UV
-        uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
-        with:
-          version: "latest"
-
-      - name: Cache UV dependencies (Unix)
-        if: runner.os != 'Windows'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~/.cache/uv
-          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-uv-
-
-      - name: Cache UV dependencies (Windows)
-        if: runner.os == 'Windows'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: ~\AppData\Local\uv\cache
-          key: ${{ runner.os }}-uv-${{ hashFiles('uv.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-uv-
-
-      - name: Install dependencies
-        run: make install-dev
-
-      - name: Run tests
-        run: make test
 
   test-cli:
     name: CLI (${{ matrix.os == 'ubuntu-latest' && 'Linux' || matrix.os == 'macos-latest' && 'macOS' || 'Windows' }})
@@ -126,7 +91,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install UV
         uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
@@ -159,11 +124,12 @@ jobs:
           uv run sigstore-a2a --help
           uv run sigstore-a2a sign --help
           uv run sigstore-a2a verify --help
+          uv run sigstore-a2a serve --help
 
   build:
     name: Build (${{ matrix.os == 'ubuntu-latest' && 'Linux' || matrix.os == 'macos-latest' && 'macOS' || 'Windows' }})
     runs-on: ${{ matrix.os }}
-    needs: [test-python-versions, test-platforms, test-cli]
+    needs: [test, test-cli]
     strategy:
       fail-fast: false
       matrix:
@@ -176,7 +142,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          python-version: '3.13'
+          python-version: '3.14'
 
       - name: Install UV
         uses: astral-sh/setup-uv@803947b9bd8e9f986429fa0c5a41c367cd732b41 # v7.2.1
@@ -214,17 +180,15 @@ jobs:
   all-tests-pass:
     name: All Tests Pass
     runs-on: ubuntu-latest
-    needs: [test-python-versions, test-platforms, test-cli, build]
+    needs: [test, test-cli, build]
     if: always()
     steps:
       - name: Check all jobs passed
         run: |
-          if [[ "${{ needs.test-python-versions.result }}" != "success" ]] || \
-             [[ "${{ needs.test-platforms.result }}" != "success" ]] || \
+          if [[ "${{ needs.test.result }}" != "success" ]] || \
              [[ "${{ needs.test-cli.result }}" != "success" ]] || \
              [[ "${{ needs.build.result }}" != "success" ]]; then
             echo "Some jobs failed"
             exit 1
           fi
           echo "All jobs passed!"
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Development Status :: 3 - Alpha",
   "Intended Audience :: Developers",
   "Topic :: Security",


### PR DESCRIPTION
## Summary

- Add Python 3.14 to the CI test matrix (now stable)
- Add `Programming Language :: Python :: 3.14` classifier to `pyproject.toml`

Closes https://github.com/sigstore/sigstore-a2a/issues/36

## Test plan

- [ ] CI passes on Python 3.14