### PR TITLE
test: add serve command tests and improve verify CLI coverage

### DIFF
--- a/tests/cli/test_cli_serve.py
+++ b/tests/cli/test_cli_serve.py
@@ -1,0 +1,138 @@
+# Copyright 2025 The Sigstore Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the serve command's FastAPI app endpoints."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from a2a.types import AgentCard
+from fastapi.testclient import TestClient
+from google.protobuf.json_format import ParseDict
+
+from sigstore_a2a.cli.serve import create_app
+
+FIXTURES_DIR = Path(__file__).parent.parent / "historic"
+
+
+def _make_signed_card_file(tmp_path: Path, card_data: dict) -> Path:
+    """Write a signed card JSON file with the given agent card data."""
+    path = tmp_path / "signed-card.json"
+    path.write_text(json.dumps({"agentCard": card_data, "attestations": {}}), encoding="utf-8")
+    return path
+
+
+def _mock_signed_card(card_data: dict):
+    """Build a mock SignedAgentCard with a real protobuf AgentCard."""
+    agent_card = ParseDict(card_data, AgentCard(), ignore_unknown_fields=True)
+    mock = MagicMock()
+    mock.agent_card = agent_card
+    return mock
+
+
+@pytest.fixture
+def v1_card_data():
+    return json.loads((FIXTURES_DIR / "v1_0" / "agentcard.json").read_text())
+
+
+@pytest.fixture
+def v0_2_card_data():
+    return json.loads((FIXTURES_DIR / "v0_2_x" / "agentcard.json").read_text())
+
+
+class TestServeEndpoints:
+    """Test the FastAPI app endpoints created by create_app."""
+
+    def test_agent_card_endpoint_serves_v1_card(self, tmp_path, v1_card_data):
+        """/.well-known/agent.json must serve the agent card data."""
+        path = _make_signed_card_file(tmp_path, v1_card_data)
+        mock = _mock_signed_card(v1_card_data)
+
+        with patch("sigstore_a2a.cli.serve.SignedAgentCard.model_validate", return_value=mock):
+            app = create_app(path, verify_on_serve=False)
+            with TestClient(app) as client:
+                resp = client.get("/.well-known/agent.json")
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["name"] == v1_card_data["name"]
+                assert "supportedInterfaces" in data
+
+    def test_agent_card_endpoint_serves_v0_2_card(self, tmp_path, v0_2_card_data):
+        """/.well-known/agent.json must serve old-format cards (v0.2.x fields dropped by protobuf)."""
+        path = _make_signed_card_file(tmp_path, v0_2_card_data)
+        mock = _mock_signed_card(v0_2_card_data)
+
+        with patch("sigstore_a2a.cli.serve.SignedAgentCard.model_validate", return_value=mock):
+            app = create_app(path, verify_on_serve=False)
+            with TestClient(app) as client:
+                resp = client.get("/.well-known/agent.json")
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["name"] == v0_2_card_data["name"]
+
+    def test_signed_card_endpoint_returns_full_envelope(self, tmp_path, v1_card_data):
+        """/.well-known/agent.signed.json must return the complete signed card."""
+        path = _make_signed_card_file(tmp_path, v1_card_data)
+        mock = _mock_signed_card(v1_card_data)
+
+        with patch("sigstore_a2a.cli.serve.SignedAgentCard.model_validate", return_value=mock):
+            app = create_app(path, verify_on_serve=False)
+            with TestClient(app) as client:
+                resp = client.get("/.well-known/agent.signed.json")
+                assert resp.status_code == 200
+                data = resp.json()
+                assert "agentCard" in data
+                assert "attestations" in data
+
+    def test_health_endpoint(self, tmp_path, v1_card_data):
+        """/health must report healthy status."""
+        path = _make_signed_card_file(tmp_path, v1_card_data)
+        mock = _mock_signed_card(v1_card_data)
+
+        with patch("sigstore_a2a.cli.serve.SignedAgentCard.model_validate", return_value=mock):
+            app = create_app(path, verify_on_serve=False)
+            with TestClient(app) as client:
+                resp = client.get("/health")
+                assert resp.status_code == 200
+                assert resp.json()["status"] == "healthy"
+                assert resp.json()["agent_loaded"] is True
+
+    def test_root_endpoint_v1_card_shows_url(self, tmp_path, v1_card_data):
+        """Root endpoint must extract URL from supportedInterfaces for v1.0 cards."""
+        path = _make_signed_card_file(tmp_path, v1_card_data)
+        mock = _mock_signed_card(v1_card_data)
+
+        with patch("sigstore_a2a.cli.serve.SignedAgentCard.model_validate", return_value=mock):
+            app = create_app(path, verify_on_serve=False)
+            with TestClient(app) as client:
+                resp = client.get("/")
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["agent"]["name"] == v1_card_data["name"]
+                assert data["agent"]["url"] == v1_card_data["supportedInterfaces"][0]["url"]
+
+    def test_root_endpoint_v0_2_card_url_is_none(self, tmp_path, v0_2_card_data):
+        """Root endpoint URL falls back to None for old cards since protobuf drops the url field."""
+        path = _make_signed_card_file(tmp_path, v0_2_card_data)
+        mock = _mock_signed_card(v0_2_card_data)
+
+        with patch("sigstore_a2a.cli.serve.SignedAgentCard.model_validate", return_value=mock):
+            app = create_app(path, verify_on_serve=False)
+            with TestClient(app) as client:
+                resp = client.get("/")
+                assert resp.status_code == 200
+                data = resp.json()
+                assert data["agent"]["name"] == v0_2_card_data["name"]

--- a/tests/cli/test_cli_verify.py
+++ b/tests/cli/test_cli_verify.py
@@ -40,12 +40,13 @@ def sample_signed_path(tmp_path: Path) -> Path:
 class _VR:
     """Simple stand-in for VerificationResult."""
 
-    def __init__(self, valid=True, errors=None, agent_card=None, identity=None, certificate=None):
+    def __init__(self, valid=True, errors=None, agent_card=None, identity=None, certificate=None, raw_card_data=None):
         self.valid = valid
         self.errors = errors or []
         self.agent_card = agent_card
         self.identity = identity
         self.certificate = certificate
+        self.raw_card_data = raw_card_data or {}
 
 
 class _RecordingVerifier:
@@ -191,6 +192,79 @@ def test_verify_constraints_are_forwarded(runner: CliRunner, sample_signed_path:
     assert getattr(constraints, "workflow", None) == "ci"
     assert getattr(constraints, "identity", None) == "dev@example.com"
     assert getattr(constraints, "identity_provider", None) == "https://accounts.google.com"
+
+
+def test_verify_displays_v1_card_details(runner: CliRunner, sample_signed_path: Path, monkeypatch):
+    """Verify CLI outputs agent card details including URL from supported_interfaces."""
+    from a2a.types import AgentCard
+    from google.protobuf.json_format import ParseDict
+
+    card = ParseDict(
+        {
+            "name": "V1 Agent",
+            "version": "2.0.0",
+            "description": "test",
+            "supportedInterfaces": [{"url": "https://example.com/a2a"}],
+            "skills": [],
+        },
+        AgentCard(),
+        ignore_unknown_fields=True,
+    )
+
+    class _CardVerifier(_RecordingVerifier):
+        return_result = _VR(valid=True, agent_card=card)
+
+    _patch_verifier(monkeypatch, _CardVerifier)
+
+    result = runner.invoke(
+        verify_cmd,
+        [
+            str(sample_signed_path),
+            "--identity",
+            "dev@example.com",
+            "--identity_provider",
+            "https://accounts.google.com",
+        ],
+        obj={"verbose": False},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "V1 Agent" in result.output
+    assert "2.0.0" in result.output
+    assert "https://example.com/a2a" in result.output
+
+
+def test_verify_displays_legacy_card_url_from_raw_data(runner: CliRunner, sample_signed_path: Path, monkeypatch):
+    """Verify CLI falls back to raw_card_data for URL when agent card has no supported_interfaces."""
+    from a2a.types import AgentCard
+    from google.protobuf.json_format import ParseDict
+
+    card = ParseDict(
+        {"name": "Legacy Agent", "version": "1.0.0", "description": "old", "skills": []},
+        AgentCard(),
+        ignore_unknown_fields=True,
+    )
+
+    class _LegacyVerifier(_RecordingVerifier):
+        return_result = _VR(valid=True, agent_card=card, raw_card_data={"url": "https://legacy.example.com"})
+
+    _patch_verifier(monkeypatch, _LegacyVerifier)
+
+    result = runner.invoke(
+        verify_cmd,
+        [
+            str(sample_signed_path),
+            "--identity",
+            "dev@example.com",
+            "--identity_provider",
+            "https://accounts.google.com",
+        ],
+        obj={"verbose": False},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "Legacy Agent" in result.output
+    assert "https://legacy.example.com" in result.output
 
 
 def test_verify_requires_existing_file(runner: CliRunner, monkeypatch, tmp_path: Path):

--- a/tests/test_compat.py
+++ b/tests/test_compat.py
@@ -251,6 +251,25 @@ class TestSignedAgentCardCompat:
         assert result["agentCard"]["name"] == card_data["name"]
         json.dumps(result)
 
+    @pytest.mark.parametrize(
+        "version_dir,filename",
+        [
+            ("v0_2_x", "agentcard.json"),
+            ("v1_0", "agentcard.json"),
+        ],
+    )
+    def test_to_dict_without_raw_card_data(self, version_dir: str, filename: str):
+        """to_dict falls back to MessageToDict when _raw_card_data is None."""
+        card_data = _load_fixture(version_dir, filename)
+        signed = _build_signed_card(card_data)
+        object.__setattr__(signed, "_raw_card_data", None)
+
+        result = signed.to_dict()
+        assert "agentCard" in result
+        assert "attestations" in result
+        assert result["agentCard"]["name"] == card_data["name"]
+        json.dumps(result)
+
 
 # ---------------------------------------------------------------------------
 # Test: Verification flow with historic card formats


### PR DESCRIPTION
## Summary

- Add `raw_card_data` to `_VR` mock in CLI verify tests — the Agent Card Details table was never exercised
- Add tests for CLI verify displaying card details with both v1.0 (`supportedInterfaces`) and legacy (`raw_card_data` URL fallback) cards
- Add `tests/cli/test_cli_serve.py` — serve command's FastAPI endpoints were entirely untested
- Add `to_dict()` test for the `MessageToDict` fallback path when `_raw_card_data` is None

## Test plan

- [x] All 92 tests pass (82 existing + 10 new)
- [x] Lint and format checks pass