### PR TITLE
ci: pin docs workflow actions to SHA digests

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -44,15 +44,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.0.0
         with:
           python-version: '3.13'
 
       - name: Install UV
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@94527f2e458b27549849d47d273a16bec83a01e9 # v7.0.0
         with:
           version: "latest"
 
@@ -65,7 +65,7 @@ jobs:
           uv run mkdocs build --strict
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: site/
 
@@ -79,5 +79,5 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v5
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
 


### PR DESCRIPTION
## Summary

Pin all GitHub Actions in `docs.yml` to full SHA digests. This was the only workflow still using floating tags (`@v7`, `@v6`, `@v5`). All other workflows were already pinned.

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `@v7` | `@9c091bb...` (v7.0.0) |
| `actions/setup-python` | `@v6` | `@ece7cb0...` (v6.0.0) |
| `astral-sh/setup-uv` | `@v7` | `@94527f2...` (v7.0.0) |
| `actions/upload-pages-artifact` | `@v5` | `@fc324d3...` (v5.0.0) |
| `actions/deploy-pages` | `@v5` | `@cd2ce8f...` (v5.0.0) |

Closes #41

## Test plan

- [x] No code changes — workflow pinning only